### PR TITLE
fix: item on list after adding new item

### DIFF
--- a/izanami-server/javascript/src/izanami/inputs/Table.js
+++ b/izanami-server/javascript/src/izanami/inputs/Table.js
@@ -287,7 +287,7 @@ export class Table extends Component {
           this.setState({error: true, errorList: this.buildErrorList(res.errorList)});
         } else {
           let items;
-          if (this.state.items.find(i => _.isEqual(i, res.data))) {
+          if (this.state.items.find(i => i.id === res.data.id)) {
             items = [...this.state.items];
           } else {
             items = [res.data, ...this.state.items].splice(0, this.props.pageSize);


### PR DESCRIPTION
Sometimes, after adding a user for example, it will be present twice in the list after the save action.
_.isEqual does not works because, the 2 users are not exactly the same, 1 have the password, the other no.

As all entities have an id, I sugggest this fix.