### PR TITLE
feat: dissociate api context and front base url

### DIFF
--- a/izanami-server/app/IzanamiLoader.scala
+++ b/izanami-server/app/IzanamiLoader.scala
@@ -55,7 +55,7 @@ package object modules {
 
     Logger.info(s"Configuration: \n$izanamiConfig")
 
-    lazy val _env: Env = izanamiConfig.contextPath match {
+    lazy val _env: Env = izanamiConfig.baseURL match {
       case "/" => wire[Env]
       case c =>
         val aFinder: AssetsFinder = assetsFinder

--- a/izanami-server/app/controllers/AuthController.scala
+++ b/izanami-server/app/controllers/AuthController.scala
@@ -92,6 +92,6 @@ class AuthController(_env: Env,
       .sign(algorithm)
 
   def logout() = Action { _ =>
-    Redirect(s"${_env.contextPath}/login").withCookies(Cookie(name = cookieName, value = "", maxAge = Some(0)))
+    Redirect(s"${_env.baseURL}/login").withCookies(Cookie(name = cookieName, value = "", maxAge = Some(0)))
   }
 }

--- a/izanami-server/app/controllers/HomeController.scala
+++ b/izanami-server/app/controllers/HomeController.scala
@@ -15,11 +15,11 @@ class HomeController(_env: Env, AuthAction: ActionBuilder[AuthContext, AnyConten
     case default: env.Default => true
     case _                    => false
   }
-  lazy val contextPath: String = _env.contextPath
+  lazy val baseURL: String = _env.baseURL
   lazy val logout: String = if (_env.izanamiConfig.logout.url.startsWith("http")) {
     _env.izanamiConfig.logout.url
   } else {
-    s"$contextPath${_env.izanamiConfig.logout.url}"
+    s"$baseURL${_env.izanamiConfig.logout.url}"
   }
 
   def index() = AuthAction { ctx =>
@@ -27,15 +27,15 @@ class HomeController(_env: Env, AuthAction: ActionBuilder[AuthContext, AnyConten
       case Some(_) =>
         Ok(
           views.html
-            .index(_env, contextPath, logout, enabledUserManagement, toJson(ctx.auth))
+            .index(_env, baseURL, logout, enabledUserManagement, toJson(ctx.auth))
         )
       case None =>
-        Redirect(s"$contextPath/login")
+        Redirect(s"$baseURL/login")
     }
   }
 
   def login() = AuthAction { ctx =>
-    Ok(views.html.index(_env, contextPath, logout, enabledUserManagement, toJson(ctx.auth)))
+    Ok(views.html.index(_env, baseURL, logout, enabledUserManagement, toJson(ctx.auth)))
   }
 
   def otherRoutes(anyPath: String) = index()

--- a/izanami-server/app/env/Env.scala
+++ b/izanami-server/app/env/Env.scala
@@ -37,6 +37,11 @@ case class Env(
   } else {
     izanamiConfig.contextPath
   }
+  val baseURL: String = if (izanamiConfig.baseURL.endsWith("/")) {
+    izanamiConfig.baseURL.dropRight(1)
+  } else {
+    izanamiConfig.baseURL
+  }
 
   implicit val scriptExecutionContext: ScriptExecutionContext =
     ScriptExecutionContext(actorSystem)

--- a/izanami-server/app/env/configuration.scala
+++ b/izanami-server/app/env/configuration.scala
@@ -54,6 +54,7 @@ object IzanamiConfig {
 case class IzanamiConfig(
     mode: Option[String],
     contextPath: String,
+    baseURL: String,
     filter: IzanamiFilter,
     db: DbConfig,
     logout: LogoutConfig,

--- a/izanami-server/app/views/index.scala.html
+++ b/izanami-server/app/views/index.scala.html
@@ -1,10 +1,11 @@
 @import play.api.libs.json.{JsValue, Json}
 
-@(_env: env.Env, contextPath: String, logout: String, enabledUserManagement: Boolean, user: JsValue)
+@(_env: env.Env, baseURL: String, logout: String, enabledUserManagement: Boolean, user: JsValue)
 
 <!DOCTYPE html>
 <html>
   <head>
+    <base href="@baseURL">
     <meta charset="UTF-8"/>
     <title>Izanami</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
@@ -23,8 +24,8 @@
     }
     <div id="app"></div>
     <script type="application/javascript">
-        window.__contextPath = '@contextPath';
-        Izanami.init(document.getElementById("app"), '@contextPath', '@logout', @enabledUserManagement, JSON.parse('@Html(Json.stringify(user))'));
+        window.__contextPath = '@baseURL';
+        Izanami.init(document.getElementById("app"), '@logout', @enabledUserManagement, JSON.parse('@Html(Json.stringify(user))'));
     </script>
   </body>
 </html>

--- a/izanami-server/conf/application.conf
+++ b/izanami-server/conf/application.conf
@@ -11,14 +11,12 @@ play.http {
 http.port=9000
 http.port=${?HTTP_PORT}
 
-base.url="/"
-base.url=${?APPLICATION_BASE_URL}
-
 izanami {
   mode = "prod"
   mode = ${?IZANAMI_MODE}
   contextPath = ${play.http.context}
-  baseURL = ${base.url}
+  baseURL = "/"
+  baseURL = ${?APPLICATION_BASE_URL}
   namespace = "izanami"
   events {
     store = "InMemory"

--- a/izanami-server/conf/application.conf
+++ b/izanami-server/conf/application.conf
@@ -11,10 +11,14 @@ play.http {
 http.port=9000
 http.port=${?HTTP_PORT}
 
+base.url="/"
+base.url=${?APPLICATION_BASE_URL}
+
 izanami {
   mode = "prod"
   mode = ${?IZANAMI_MODE}
   contextPath = ${play.http.context}
+  baseURL = ${base.url}
   namespace = "izanami"
   events {
     store = "InMemory"

--- a/izanami-server/javascript/src/izanami.js
+++ b/izanami-server/javascript/src/izanami.js
@@ -24,7 +24,7 @@ import { buildRoutedApp } from './izanami/index';
 import ReactDOM from 'react-dom';
 import { createBrowserHistory } from "history";
 
-export function init(node, contextPath, logout, enabledUserManagement, user) {
+export function init(node, logout, enabledUserManagement, user) {
     let history;
     if (window.__contextPath && window.__contextPath !== '') {
         history = createBrowserHistory({basename:window.__contextPath});
@@ -32,5 +32,5 @@ export function init(node, contextPath, logout, enabledUserManagement, user) {
         history = createBrowserHistory();
     }
   const RoutedIzanamiApp = buildRoutedApp(history);
-  ReactDOM.render(<RoutedIzanamiApp user={user} contextPath={contextPath} logout={logout} enabledUserManagement={enabledUserManagement}/>, node);
+  ReactDOM.render(<RoutedIzanamiApp user={user} logout={logout} enabledUserManagement={enabledUserManagement}/>, node);
 }

--- a/izanami-server/test/domains/script/ScriptSpec.scala
+++ b/izanami-server/test/domains/script/ScriptSpec.scala
@@ -64,6 +64,7 @@ class ScriptSpec extends PlaySpec with OneServerPerSuiteWithComponents with Scal
   val config = IzanamiConfig(
     Some("dev"),
     "/",
+    "/",
     Default(DefaultFilter(Seq(), "", "", "", ApiKeyHeaders("", ""))),
     DbConfig("", None, None, None, None, None),
     LogoutConfig(""),


### PR DESCRIPTION
Feature to dissociate backend http context and front base url
How it should work

Use case 1:  izanami run on /
   Keep default value
Use case 2: you should run izanami under a path /foo
  Set application context + base URL to /foo
Use case 3: behind a proxy pass /bar
  Keep application context to /  + set baseUrl = /bar