### PR TITLE
Reduce lodash bundle size by import only specific func

### DIFF
--- a/izanami-clients/react/src/experiments.js
+++ b/izanami-clients/react/src/experiments.js
@@ -5,8 +5,8 @@ import React, { Component } from 'react';
 import { string, object, bool, func } from 'prop-types';
 import deepEqual from 'deep-equal';
 import deepmerge from 'deepmerge';
-import { get } from 'lodash';
-import * as Api from './api'
+import { get } from 'lodash/get';
+import * as Api from './api';
 
 if (!window.Symbol) {
     window.Symbol = Symbol;

--- a/izanami-clients/react/src/features.js
+++ b/izanami-clients/react/src/features.js
@@ -5,10 +5,11 @@ import React, { Component } from 'react';
 import { func, string, bool, object, node, oneOfType, arrayOf } from 'prop-types';
 import deepEqual from 'deep-equal';
 import deepmerge from 'deepmerge';
-import { get, isFunction } from 'lodash';
-import * as Api from './api'
-import Debug from './debug'
-import { arrayPathToString, getCleanedArrayPath, getIsActive } from './util'
+import { get } from 'lodash/get';
+import { isFunction } from "lodash/isFunction";
+import * as Api from './api';
+import Debug from './debug';
+import { arrayPathToString, getCleanedArrayPath, getIsActive } from './util';
 
 
 if (!window.Symbol) {

--- a/izanami-clients/react/src/index.js
+++ b/izanami-clients/react/src/index.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
 import { FeatureProvider } from './features';
 import { ExperimentsProvider } from './experiments';
-import * as Api from './api'
+import * as Api from './api';
 import { object, bool, string, func, oneOfType } from 'prop-types';
-import {isFunction, isString} from 'lodash'
+import { isFunction } from 'lodash/isFunction';
+import { isString } from 'lodash/isString';
 
 export * as Api from './api';
 export * from './features';

--- a/izanami-clients/react/src/util.js
+++ b/izanami-clients/react/src/util.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash'
+import { get } from 'lodash/get'
 
 export const getIsActive = (features, path) => {
   return path


### PR DESCRIPTION
By importing only specific method in multiline, webpack or parcel doesn't import all lodash lib but only the code needed.  For an simple app using Izanami client, the size of lodash in bundle reduced from 70.3 kb to 8.42 kb. 

Before
<img width="860" alt="capture d ecran 2018-08-19 a 09 40 00" src="https://user-images.githubusercontent.com/5230135/44308240-e74e3000-a3b1-11e8-840b-903743ba2d90.png">
After:
<img width="773" alt="capture d ecran 2018-08-19 a 09 40 50" src="https://user-images.githubusercontent.com/5230135/44308245-ee753e00-a3b1-11e8-9568-e8468fd5b3af.png">
