### PR TITLE
Upgrade docker base image to openjdk:10-jre-slim

### DIFF
--- a/izanami-server/build.sbt
+++ b/izanami-server/build.sbt
@@ -117,7 +117,7 @@ packageName in Docker := "izanami"
 
 maintainer in Docker := "MAIF Team <maif@maif.fr>"
 
-dockerBaseImage := "openjdk:8"
+dockerBaseImage := "openjdk:10-jre-slim"
 
 dockerCommands ++= Seq(
   Cmd("ENV", "APP_NAME izanami"),


### PR DESCRIPTION
Java 10 introduces some much needed optimization to memory and garbage collection when running the JVM in a container.  Choosing the jre-slim version has a nice side effect of bringing the size of the image down to around 400 mb.

