### PR TITLE
Add SBT_OPTS in order to compile the sources. Fix #243

### DIFF
--- a/izanami-documentation/src/main/paradox/getizanami/fromsources.md
+++ b/izanami-documentation/src/main/paradox/getizanami/fromsources.md
@@ -31,6 +31,12 @@ yarn build
 
 ## Package the server 
 
+Allow the compiler to use more memory : 
+
+```bash
+SBT_OPTS="-Xmx2G -Xss20M -XX:MaxMetaspaceSize=512M"
+```
+
 From the root folder 
 
 ### Build the native package 


### PR DESCRIPTION
Hi, 

thanks for the work. Here is a simple fix of the documentation in order to add a missing env variable in order to compile with sbt.

Best regards