### PR TITLE
Better handling of SSE

### DIFF
--- a/izanami-clients/jvm/src/main/scala/izanami/commons/client.scala
+++ b/izanami-clients/jvm/src/main/scala/izanami/commons/client.scala
@@ -235,4 +235,5 @@ private[izanami] class HttpClient(system: ActorSystem, config: ClientConfig) {
               s => List(s)
             )
       }
+      .filter { _.`type` != "KEEP_ALIVE" }
 }

--- a/izanami-clients/node/package-lock.json
+++ b/izanami-clients/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "izanami-node",
-  "version": "1.4.5",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/izanami-clients/react/package-lock.json
+++ b/izanami-clients/react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-izanami",
-  "version": "1.4.5",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/izanami-server/app/domains/commons.scala
+++ b/izanami-server/app/domains/commons.scala
@@ -371,6 +371,7 @@ object Domain {
   case object User       extends Domain
   case object Script     extends Domain
   case object Webhook    extends Domain
+  case object Unknown    extends Domain
 
   val reads: Reads[Domain] = Reads[Domain] {
     case JsString(s) if s === "Experiment" => JsSuccess(Experiment)
@@ -379,6 +380,7 @@ object Domain {
     case JsString(s) if s === "Feature"    => JsSuccess(Feature)
     case JsString(s) if s === "User"       => JsSuccess(User)
     case JsString(s) if s === "Webhook"    => JsSuccess(Webhook)
+    case JsString(s) if s === "Unknown"    => JsSuccess(Unknown)
     case _                                 => JsError("domain.invalid")
   }
 
@@ -390,6 +392,7 @@ object Domain {
     case User       => JsString("User")
     case Script     => JsString("Script")
     case Webhook    => JsString("Webhook")
+    case Unknown    => JsString("Unknown")
   }
 
   implicit val format: Format[Domain] = Format(reads, writes)

--- a/izanami-server/javascript/src/izanami/helpers/TreeData.js
+++ b/izanami-server/javascript/src/izanami/helpers/TreeData.js
@@ -34,7 +34,6 @@ export function addOrUpdateInTree(segments, value, tree) {
 function createTree(key, segments, value) {
   const [head, ...rest] = segments || [];
   const id = `${key}:${head}`;
-  console.log("id", id);
   if (rest.length > 0) {
     return {
       key: head,

--- a/izanami-server/javascript/src/izanami/inputs/KeyInput.js
+++ b/izanami-server/javascript/src/izanami/inputs/KeyInput.js
@@ -305,7 +305,7 @@ export class KeyInput extends Component {
                 <div className="keypicker-input" style={{ overflow: "hidden" }}>
                   <input
                     type="text"
-                    size={`${this.state.textValue.length}`}
+                    size={`${(this.state.textValue || "").length}`}
                     onChange={this.computeValue}
                     value={this.state.textValue}
                     onFocus={this.onFocus}

--- a/izanami-server/javascript/src/izanami/services/events.js
+++ b/izanami-server/javascript/src/izanami/services/events.js
@@ -28,7 +28,9 @@ const IzanamiEvents = {
         e => {
           console.debug("New event", e);
           const data = JSON.parse(e.data);
-          callback.forEach(cb => cb(data));
+          if (data.type !== 'KEEP_ALIVE') {          
+            callback.forEach(cb => cb(data));
+          }
         },
         false
       );

--- a/izanami-server/javascript/src/izanami/services/events.js
+++ b/izanami-server/javascript/src/izanami/services/events.js
@@ -18,13 +18,15 @@ const IzanamiEvents = {
         "error",
         e => {
           console.error("SSE error", e);
+          IzanamiEvents.stop()
+          IzanamiEvents.start()
         },
         false
       );
       eventSource.addEventListener(
         "message",
         e => {
-          console.log("New event", e);
+          console.debug("New event", e);
           const data = JSON.parse(e.data);
           callback.forEach(cb => cb(data));
         },

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.3.2


### PR DESCRIPTION
fix #297 

This PR add a keep alive message in the SSE to keep the http connection alive. 
This should fix the warnings on the client side due to an idle timeout that close the connection. 