### PR TITLE
Render Pending component while fetching izanami config

### DIFF
--- a/izanami-clients/react/readme.md
+++ b/izanami-clients/react/readme.md
@@ -65,6 +65,9 @@ Once you the provider configured, you can switch code depending on a feature :
 
 ```jsx harmony
 <Feature path="izanami.example.deleteAll">
+  <Pending>
+    <div>Fetching izanami features configuration...</div>
+  </Pending>
   <Enabled>
     <tr>
       <td></td>

--- a/izanami-clients/react/src/api.js
+++ b/izanami-clients/react/src/api.js
@@ -6,7 +6,7 @@ export function izanamiReload(id) {
   let izanamiFetch = izanamiFetchs[id];
   if (izanamiFetch) {
       console.debug("Fetching for id ", id);
-      izanamiFetch().then(r => r.json()).then(data => {
+      return izanamiFetch().then(r => r.json()).then(data => {
           const listeners = izanamiListeners[id] || [];
           listeners.forEach(l => {
               try {

--- a/izanami-clients/react/src/features.js
+++ b/izanami-clients/react/src/features.js
@@ -108,8 +108,8 @@ export class Feature extends Component {
       }
     }
     if (this.state.isFetchPending && !isEmpty(pendingChildren)) {
-      if (debug) console.log('[Features] IzanamiProvider fetchFrom request is pending, rendering first <Pending /> component');
       if (debug) {
+        console.log('[Features] IzanamiProvider fetchFrom request is pending, rendering first <Pending /> component');
         return (
           <Debug isActive={ isActive } path={ path }>
             {pendingChildren[0]}

--- a/izanami-clients/react/src/index.js
+++ b/izanami-clients/react/src/index.js
@@ -37,6 +37,7 @@ export class IzanamiProvider extends Component {
   state = {
     loading: false,
     fetched: {},
+    isFetchPending: Boolean(this.props.fetchFrom),
   };
 
   constructor(args) {
@@ -81,7 +82,11 @@ export class IzanamiProvider extends Component {
       }
       Api.register(id, this.onDataLoaded);
       this.setState({loading: true});
-      Api.izanamiReload(id, this.props.fetchHeaders);
+      Api.izanamiReload(id, this.props.fetchHeaders).finally(() => {
+        this.setState({
+          isFetchPending: false
+        })
+      })
     }
   }
 
@@ -96,7 +101,7 @@ export class IzanamiProvider extends Component {
         const { debug, features, featuresFallback, experiments, experimentsFallback } = this.state.fetched;
         const id = this.id();
         return (
-          <FeatureProvider id={id} debug={debug} features={features || {}} fallback={featuresFallback} fetchFrom={this.props.fetchFrom}>
+          <FeatureProvider isFetchPending={this.state.isFetchPending} id={id} debug={debug} features={features || {}} fallback={featuresFallback} fetchFrom={this.props.fetchFrom}>
             <ExperimentsProvider id={id} debug={debug} experiments={experiments || {}} experimentsFallback={experimentsFallback}>
               {this.props.children}
             </ExperimentsProvider>


### PR DESCRIPTION
Fix #323 

## Description

I created a new component `Pending` that will be rendered while the fetch request is pending: 

```jsx
<Feature path="izanami.example.deleteAll">
   <Pending> 
      <div>This will be rendered while the fetch request is pending</div>
   </Pending>
</Feature>
```

Would it be possible to get a new release after this got merged?

Thanks
