### PR TITLE
Update doc about swagger. MAIF/Izanami#310

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,7 +68,8 @@ You must add the dependency and its licence in https://github.com/MAIF/izanami/b
 if you add features to Izanami, don't forget to modify the user manual, the swagger file and the clients too
 
 * https://github.com/MAIF/izanami/tree/master/izanami-documentation/src/main/paradox
-* https://github.com/MAIF/izanami/blob/master/izanami-server/app/controllers/SwaggerController.scala
+* https://github.com/MAIF/izanami/blob/master/izanami-server/conf/swagger.yml
+* https://github.com/MAIF/izanami/blob/master/izanami-server/conf/routes
 * https://github.com/MAIF/izanami/blob/master/izanami-clients/jvm
 * https://github.com/MAIF/izanami/blob/master/izanami-clients/node
 * https://github.com/MAIF/izanami/blob/master/izanami-clients/react
@@ -77,13 +78,13 @@ if you add features to Izanami, don't forget to modify the user manual, the swag
 to build the documentation, run the following command at the root of the repository
 
 ```sh
-sbt 'izanami-documentation/generateDoc' 
+sbt 'izanami-documentation/generateDoc' 'izanami-server/generateDoc'
 ```
 
 To get the documentation generated on each change 
 
 ```sh
-sbt '~izanami-documentation/generateDoc' 
+sbt '~izanami-documentation/generateDoc' '~izanami-server/generateDoc'
 ```
 
 ## Source style

--- a/docs/swagger/swagger-ui.html
+++ b/docs/swagger/swagger-ui.html
@@ -1,0 +1,56 @@
+<html lang="en"><head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.23.3/swagger-ui.css">
+    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist@3.23.3/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist@3.23.3/favicon-16x16.png" sizes="16x16">
+    <style>
+        html
+        {
+            box-sizing: border-box;
+            overflow: -moz-scrollbars-vertical;
+            overflow-y: scroll;
+        }
+        *,
+        *:before,
+        *:after
+        {
+            box-sizing: inherit;
+        }
+
+        body {
+            margin:0;
+            background: #fafafa;
+        }
+    </style>
+</head>
+
+<body>
+<div id="swagger-ui"></div>
+
+<script src="https://unpkg.com/swagger-ui-dist@3.23.3/swagger-ui-bundle.js"></script>
+<script src="https://unpkg.com/swagger-ui-dist@3.23.3/swagger-ui-standalone-preset.js"></script>
+<script>
+  window.onload = function() {
+    // Begin Swagger UI call region
+    const ui = SwaggerUIBundle({
+      "dom_id": "#swagger-ui",
+      deepLinking: true,
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ],
+      plugins: [
+        SwaggerUIBundle.plugins.DownloadUrl
+      ],
+      layout: "StandaloneLayout",
+      validatorUrl: "https://validator.swagger.io/validator",
+      url: "swagger.json"
+    })
+    // End Swagger UI call region
+    window.ui = ui
+  }
+</script>
+
+

--- a/izanami-documentation/src/main/paradox/api.md
+++ b/izanami-documentation/src/main/paradox/api.md
@@ -96,3 +96,9 @@ Go to the @ref[experiments API doc](experiments/api.md)
 ## Api keys API
 
 * TODO
+
+## Where can I find an OpenApi ?
+
+Go see the [open api](../swagger/swagger-ui.html)
+
+Once you have an instance running (see @ref[Quickstart](quickstart.md)), you can find the swagger doc at `http://localhost:9000/docs/swagger-ui/index.html?url=/assets/swagger.json`.

--- a/izanami-server/build.sbt
+++ b/izanami-server/build.sbt
@@ -221,3 +221,14 @@ dockerUsername := Some("maif")
 dockerEntrypoint := Seq("/opt/docker/bin/start.sh")
 
 dockerUpdateLatest := true
+
+lazy val generateDoc = taskKey[Unit]("Copy api doc")
+
+generateDoc := {
+  val p = project
+  (swagger in Compile).value
+  val swaggerFile = target.value / "swagger" / "swagger.json"
+  val targetDoc  = p.base.getParentFile / "docs"/ "swagger" / "swagger.json"
+  IO.delete(targetDoc)
+  IO.copyDirectory(swaggerFile, targetDoc)
+}

--- a/izanami-server/conf/application.conf
+++ b/izanami-server/conf/application.conf
@@ -303,7 +303,7 @@ izanami {
       headerGatewayStateResp = ${?FILTER_GATEWAY_STATE_RESP_HEADER_NAME}
     }
     default {
-      allowedPaths = [${?FILTER_EXLUSION}, ${?FILTER_EXLUSION_1}, ${?FILTER_EXLUSION_2}, ${?FILTER_EXLUSION_3}, "/", "/login", "/api/login","/logout","/api/logout","/favicon.ico","/assets/.*","/explorer.*","/users.*", "/experiments.*", "/scripts.*", "/webhooks.*", "/configurations.*", "/features.*", "/api/auth/.*"]
+      allowedPaths = [${?FILTER_EXLUSION}, ${?FILTER_EXLUSION_1}, ${?FILTER_EXLUSION_2}, ${?FILTER_EXLUSION_3}, "/", "/login", "/api/login","/logout","/api/logout","/favicon.ico","/assets/.*","/docs/.*","/explorer.*","/users.*", "/experiments.*", "/scripts.*", "/webhooks.*", "/configurations.*", "/features.*", "/api/auth/.*"]
       sharedKey = "none"
       sharedKey = ${?FILTER_CLAIM_SHAREDKEY}
       cookieClaim = "Izanami"


### PR DESCRIPTION
Hello, I tried to update the documentation. I often want to look at the swagger doc and find it hard each time to remenber where it is. This change is about making the swagger doc more accessible for people :

- in a running Izanami instance, doc can be found at `/docs/swagger-ui/index.html?url=/assets/swagger.json`. I documented this in the manual to make it easier to find and I fixed access control as I had `Bad claims` response when tried to access it.

- made the swagger doc accessible with the rest of the docs. When deployed on the official Izanami website, it would be accessible at `https://maif.github.io/izanami/swagger/swagger-ui.html`. 

Details of the changes I made :

- generate swagger doc from izanami-server sources and copy it in docs/
- add swagger ui to display swagger doc
- change contributing doc to update swagger source files
- change contributing doc to generator swagger doc
- add references to swagger doc in api doc 
- add a link where swagger doc can be found in a running izanami instance in api doc 
- make swagger doc accessible without claims in application.conf

Tell me what you think about this change, if it's ok with you or if you want to change some parts 😄 

