### PR TITLE
Make the node express proxy more configurable

### DIFF
--- a/izanami-clients/node/index.js
+++ b/izanami-clients/node/index.js
@@ -15,7 +15,7 @@ class IzanamiFeatureClient {
     const dottyKey = key.replace(/:/g, ".");
     const url = this.config.host + "/api/features/" + columnKey + "/check";
     if (this.config.env === 'DEV') {
-      const value = get(this.config.fallbackConfig, dottyKey) || { active: false };
+      const value = get(this.config.fallbackConfig, dottyKey) || {active: false};
       return Promise.resolve(value.active || false);
     }
     const config = this.config;
@@ -33,11 +33,11 @@ class IzanamiFeatureClient {
         if (r.status === 200) {
           return r.json().then(t => !!t.active);
         } else if (r.status === 404) {
-          return (get(this.config.fallbackConfig, dottyKey) || { active: false }).active;
+          return (get(this.config.fallbackConfig, dottyKey) || {active: false}).active;
         } else {
-          return Promise.reject({ message: 'Bad response', response: r });
+          return Promise.reject({message: 'Bad response', response: r});
         }
-      } catch(e) {
+      } catch (e) {
         return Promise.reject(e);
       }
     });
@@ -65,7 +65,7 @@ class IzanamiFeatureClient {
         return r.json().then(f => {
           return deepmerge(this.config.fallbackConfig, f)
         });
-      } catch(e) {
+      } catch (e) {
         return Promise.reject(e);
       }
     });
@@ -108,9 +108,9 @@ class IzanamiConfigClient {
         } else if (r.status === 404) {
           return get(this.conf.fallbackConfig, dottyKey) || {};
         } else {
-          return Promise.reject({ message: 'Bad response', response: r });
+          return Promise.reject({message: 'Bad response', response: r});
         }
-      } catch(e) {
+      } catch (e) {
         return Promise.reject(e);
       }
     });
@@ -136,7 +136,7 @@ class IzanamiConfigClient {
         return r.json().then(f => {
           return deepmerge(this.conf.fallbackConfig, f)
         });
-      } catch(e) {
+      } catch (e) {
         return Promise.reject(e);
       }
     });
@@ -178,9 +178,9 @@ class IzanamiExperimentsClient {
         } else if (r.status === 404) {
           return get(this.conf.fallbackConfig, dottyKey) || {};
         } else {
-          return Promise.reject({ message: 'Bad response', response: r });
+          return Promise.reject({message: 'Bad response', response: r});
         }
-      } catch(e) {
+      } catch (e) {
         return Promise.reject(e);
       }
     });
@@ -206,7 +206,7 @@ class IzanamiExperimentsClient {
         return r.json().then(f => {
           return deepmerge(this.conf.fallbackConfig, f)
         });
-      } catch(e) {
+      } catch (e) {
         return Promise.reject(e);
       }
     });
@@ -236,9 +236,9 @@ class IzanamiExperimentsClient {
           const value = get(this.conf.fallbackConfig, dottyKey) || {};
           return Promise.resolve(value.active || {});
         } else {
-          return Promise.reject({ message: 'Bad response', response: r });
+          return Promise.reject({message: 'Bad response', response: r});
         }
-      } catch(e) {
+      } catch (e) {
         return Promise.reject(e);
       }
     });
@@ -264,9 +264,9 @@ class IzanamiExperimentsClient {
         if (r.status === 200 || r.state === 404) {
           return r;
         } else {
-          return Promise.reject({ message: 'Bad response', response: r });
+          return Promise.reject({message: 'Bad response', response: r});
         }
-      } catch(e) {
+      } catch (e) {
         return Promise.reject(e);
       }
     });
@@ -292,9 +292,9 @@ class IzanamiExperimentsClient {
         if (r.status === 200 || r.state === 404) {
           return r;
         } else {
-          return Promise.reject({ message: 'Bad response', response: r });
+          return Promise.reject({message: 'Bad response', response: r});
         }
-      } catch(e) {
+      } catch (e) {
         return Promise.reject(e);
       }
     });
@@ -331,24 +331,26 @@ module.exports = {
       path
     } = config;
 
+
     app.get(sessionPath, (req, res) => {
-        const [features, experiments, configurations] = Promise.all([
-            (!!featureClient ? featureClient.features(path, { user: req.user_email }) : {}),
-            (!!experimentsClient ? experimentsClient.experiments(path, req.user_email) : {}),
-            (!!configClient ? configClient.configs(path) : {})
-        ]);
-        res.send({ experiments, features, configurations });
+      Promise.all([
+        (!!featureClient ? featureClient.features(path, {user: req.user_email}) : {}),
+        (!!experimentsClient ? experimentsClient.experiments(path, req.user_email) : {}),
+        (!!configClient ? configClient.configs(path) : {})
+      ]).then(([features, experiments, configurations]) => {
+        res.send({experiments, features, configurations});
+      });
     });
 
     app.post(experimentWonPath, (req, res) => {
       experimentsClient.won(req.query.experiment, req.user_email).then(() => {
-        res.send({ done: true });
+        res.send({done: true});
       });
     });
 
     app.post(experimentDisplayedPath, (req, res) => {
       experimentsClient.displayed(req.query.experiment, req.user_email).then(() => {
-        res.send({ done: true });
+        res.send({done: true});
       });
     });
   }

--- a/izanami-clients/node/index.js
+++ b/izanami-clients/node/index.js
@@ -326,6 +326,8 @@ module.exports = {
       experimentsClient,
       app,
       sessionPath = '/api/me',
+      featureContextFromRequest = (req) => ({user: req.user_email}),
+      experimentsIdFromRequest = (req) => req.user_email,
       experimentWonPath = '/api/experiments/won',
       experimentDisplayedPath = '/api/experiments/displayed',
       path
@@ -334,8 +336,8 @@ module.exports = {
 
     app.get(sessionPath, (req, res) => {
       Promise.all([
-        (!!featureClient ? featureClient.features(path, {user: req.user_email}) : {}),
-        (!!experimentsClient ? experimentsClient.experiments(path, req.user_email) : {}),
+        (!!featureClient ? featureClient.features(path, featureContextFromRequest(req)) : {}),
+        (!!experimentsClient ? experimentsClient.experiments(path, experimentsIdFromRequest(req)) : {}),
         (!!configClient ? configClient.configs(path) : {})
       ]).then(([features, experiments, configurations]) => {
         res.send({experiments, features, configurations});
@@ -343,13 +345,13 @@ module.exports = {
     });
 
     app.post(experimentWonPath, (req, res) => {
-      experimentsClient.won(req.query.experiment, req.user_email).then(() => {
+      experimentsClient.won(req.query.experiment, experimentsIdFromRequest(req)).then(() => {
         res.send({done: true});
       });
     });
 
     app.post(experimentDisplayedPath, (req, res) => {
-      experimentsClient.displayed(req.query.experiment, req.user_email).then(() => {
+      experimentsClient.displayed(req.query.experiment, experimentsIdFromRequest(req)).then(() => {
         res.send({done: true});
       });
     });

--- a/izanami-clients/node/index.js
+++ b/izanami-clients/node/index.js
@@ -1,4 +1,4 @@
-const _ = require('lodash');
+const get = require('lodash/get');
 const deepmerge = require('deepmerge');
 const fetch = require('isomorphic-fetch');
 
@@ -15,7 +15,7 @@ class IzanamiFeatureClient {
     const dottyKey = key.replace(/:/g, ".");
     const url = this.config.host + "/api/features/" + columnKey + "/check";
     if (this.config.env === 'DEV') {
-      const value = _.get(this.config.fallbackConfig, dottyKey) || { active: false };
+      const value = get(this.config.fallbackConfig, dottyKey) || { active: false };
       return Promise.resolve(value.active || false);
     }
     const config = this.config;
@@ -33,7 +33,7 @@ class IzanamiFeatureClient {
         if (r.status === 200) {
           return r.json().then(t => !!t.active);
         } else if (r.status === 404) {
-          return (_.get(this.config.fallbackConfig, dottyKey) || { active: false }).active;
+          return (get(this.config.fallbackConfig, dottyKey) || { active: false }).active;
         } else {
           return Promise.reject({ message: 'Bad response', response: r });
         }
@@ -48,7 +48,7 @@ class IzanamiFeatureClient {
     const dottyKey = pattern.replace(/:/g, ".");
     const url = this.config.host + "/api/tree/features?pattern=" + columnPattern;
     if (this.config.env === 'DEV') {
-      return Promise.resolve(_.get(this.config.fallbackConfig, dottyKey));
+      return Promise.resolve(get(this.config.fallbackConfig, dottyKey));
     }
     const config = this.config;
     return fetch(url, {
@@ -85,7 +85,7 @@ class IzanamiConfigClient {
     const dottyKey = key.replace(/:/g, ".");
     const url = this.conf.host + "/api/configs/" + columnKey;
     if (this.conf.env === 'DEV') {
-      const value = _.get(this.conf.fallbackConfig, dottyKey) || {};
+      const value = get(this.conf.fallbackConfig, dottyKey) || {};
       return Promise.resolve(value.active || {});
     }
     const conf = this.conf;
@@ -102,11 +102,11 @@ class IzanamiConfigClient {
         if (r.status === 200) {
           return r.json().then(t => {
             const value = t.value;
-            const mergedValue = deepmerge(_.get(this.conf.fallbackConfig, dottyKey), value);
+            const mergedValue = deepmerge(get(this.conf.fallbackConfig, dottyKey), value);
             return mergedValue || {}
           });
         } else if (r.status === 404) {
-          return _.get(this.conf.fallbackConfig, dottyKey) || {};
+          return get(this.conf.fallbackConfig, dottyKey) || {};
         } else {
           return Promise.reject({ message: 'Bad response', response: r });
         }
@@ -121,7 +121,7 @@ class IzanamiConfigClient {
     const dottyKey = pattern.replace(/:/g, ".");
     const url = this.conf.host + "/api/tree/configs?pattern=" + columnPattern;
     if (this.conf.env === 'DEV') {
-      return Promise(_.get(this.conf.fallbackConfig, dottyKey));
+      return Promise(get(this.conf.fallbackConfig, dottyKey));
     }
     return fetch(url, {
       method: 'GET',
@@ -156,7 +156,7 @@ class IzanamiExperimentsClient {
     const dottyKey = key.replace(/:/g, ".");
     const url = this.conf.host + "/api/experiments/" + columnKey;
     if (this.conf.env === 'DEV') {
-      const value = _.get(this.conf.fallbackConfig, dottyKey) || {};
+      const value = get(this.conf.fallbackConfig, dottyKey) || {};
       return Promise.resolve(value.active || {});
     }
     return fetch(url, {
@@ -172,11 +172,11 @@ class IzanamiExperimentsClient {
         if (r.status === 200) {
           return r.json().then(t => {
             const value = JSON.parse(t.value);
-            const mergedValue = deepmerge(_.get(this.conf.fallbackConfig, dottyKey), value);
+            const mergedValue = deepmerge(get(this.conf.fallbackConfig, dottyKey), value);
             return mergedValue || {}
           });
         } else if (r.status === 404) {
-          return _.get(this.conf.fallbackConfig, dottyKey) || {};
+          return get(this.conf.fallbackConfig, dottyKey) || {};
         } else {
           return Promise.reject({ message: 'Bad response', response: r });
         }
@@ -191,7 +191,7 @@ class IzanamiExperimentsClient {
     const dottyKey = pattern.replace(/:/g, ".");
     const url = this.conf.host + "/api/tree/experiments?pattern=" + columnPattern + "&clientId=" + clientId;
     if (this.conf.env === 'DEV') {
-      return Promise.resolve(_.get(this.conf.fallbackConfig, dottyKey));
+      return Promise.resolve(get(this.conf.fallbackConfig, dottyKey));
     }
     return fetch(url, {
       method: 'GET',
@@ -217,7 +217,7 @@ class IzanamiExperimentsClient {
     const dottyKey = key.replace(/:/g, ".");
     const url = this.conf.host + "/api/experiments/" + columnKey + "/variant?clientId=" + clientId
     if (this.conf.env === 'DEV') {
-      const value = _.get(this.conf.fallbackConfig, dottyKey) || {};
+      const value = get(this.conf.fallbackConfig, dottyKey) || {};
       return Promise.resolve(value.active || {});
     }
     return fetch(url, {
@@ -233,7 +233,7 @@ class IzanamiExperimentsClient {
         if (r.status === 200) {
           return r.json();
         } else if (r.status === 404) {
-          const value = _.get(this.conf.fallbackConfig, dottyKey) || {};
+          const value = get(this.conf.fallbackConfig, dottyKey) || {};
           return Promise.resolve(value.active || {});
         } else {
           return Promise.reject({ message: 'Bad response', response: r });

--- a/izanami-clients/node/index.js
+++ b/izanami-clients/node/index.js
@@ -320,9 +320,18 @@ module.exports = {
   experimentsClient: (config) => new IzanamiExperimentsClient(config),
   expressProxy(config) {
 
-    const { featureClient, configClient, experimentsClient, app, sessionPath, experimentWonPath, experimentDisplayedPath, path } = config;
+    const {
+      featureClient,
+      configClient,
+      experimentsClient,
+      app,
+      sessionPath = '/api/me',
+      experimentWonPath = '/api/experiments/won',
+      experimentDisplayedPath = '/api/experiments/displayed',
+      path
+    } = config;
 
-    app.get(sessionPath || '/api/me', (req, res) => {
+    app.get(sessionPath, (req, res) => {
         const [features, experiments, configurations] = Promise.all([
             (!!featureClient ? featureClient.features(path, { user: req.user_email }) : {}),
             (!!experimentsClient ? experimentsClient.experiments(path, req.user_email) : {}),
@@ -331,13 +340,13 @@ module.exports = {
         res.send({ experiments, features, configurations });
     });
 
-    app.post(experimentWonPath || '/api/experiments/won', (req, res) => {
+    app.post(experimentWonPath, (req, res) => {
       experimentsClient.won(req.query.experiment, req.user_email).then(() => {
         res.send({ done: true });
       });
     });
 
-    app.post(experimentDisplayedPath || '/api/experiments/displayed', (req, res) => {
+    app.post(experimentDisplayedPath, (req, res) => {
       experimentsClient.displayed(req.query.experiment, req.user_email).then(() => {
         res.send({ done: true });
       });

--- a/izanami-clients/node/index.js
+++ b/izanami-clients/node/index.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const deepmerge = require('deepmerge');
 const fetch = require('isomorphic-fetch');
 
-class IzanamicFeatureClient {
+class IzanamiFeatureClient {
 
   constructor(config) {
     this.config = config;
@@ -315,7 +315,7 @@ module.exports = {
     clientSecret: '--',
     env: 'PROD'
   },
-  featureClient: (config) => new IzanamicFeatureClient(config),
+  featureClient: (config) => new IzanamiFeatureClient(config),
   configClient: (config) => new IzanamiConfigClient(config),
   experimentsClient: (config) => new IzanamiExperimentsClient(config),
   expressProxy(config) {

--- a/izanami-clients/node/index.js
+++ b/izanami-clients/node/index.js
@@ -16,7 +16,7 @@ class IzanamiFeatureClient {
     const url = this.config.host + "/api/features/" + columnKey + "/check";
     if (this.config.env === 'DEV') {
       const value = _.get(this.config.fallbackConfig, dottyKey) || { active: false };
-      return new Promise((s, f) => s(value.active || false));
+      return Promise.resolve(value.active || false);
     }
     const config = this.config;
     return fetch(url, {
@@ -35,10 +35,10 @@ class IzanamiFeatureClient {
         } else if (r.status === 404) {
           return (_.get(this.config.fallbackConfig, dottyKey) || { active: false }).active;
         } else {
-          return new Promise((s, f) => f({ message: 'Bad response', response: r }));
+          return Promise.reject({ message: 'Bad response', response: r });
         }
       } catch(e) {
-        return new Promise((s, f) => f(e));
+        return Promise.reject(e);
       }
     });
   };
@@ -48,7 +48,7 @@ class IzanamiFeatureClient {
     const dottyKey = pattern.replace(/:/g, ".");
     const url = this.config.host + "/api/tree/features?pattern=" + columnPattern;
     if (this.config.env === 'DEV') {
-      return new Promise((s, f) => s(_.get(this.config.fallbackConfig, dottyKey)));
+      return Promise.resolve(_.get(this.config.fallbackConfig, dottyKey));
     }
     const config = this.config;
     return fetch(url, {
@@ -66,7 +66,7 @@ class IzanamiFeatureClient {
           return deepmerge(this.config.fallbackConfig, f)
         });
       } catch(e) {
-        return new Promise((s, f) => f(e));
+        return Promise.reject(e);
       }
     });
   };
@@ -86,7 +86,7 @@ class IzanamiConfigClient {
     const url = this.conf.host + "/api/configs/" + columnKey;
     if (this.conf.env === 'DEV') {
       const value = _.get(this.conf.fallbackConfig, dottyKey) || {};
-      return new Promise((s, f) => s(value.active || {}));
+      return Promise.resolve(value.active || {});
     }
     const conf = this.conf;
     return fetch(url, {
@@ -108,10 +108,10 @@ class IzanamiConfigClient {
         } else if (r.status === 404) {
           return _.get(this.conf.fallbackConfig, dottyKey) || {};
         } else {
-          return new Promise((s, f) => f({ message: 'Bad response', response: r }));
+          return Promise.reject({ message: 'Bad response', response: r });
         }
       } catch(e) {
-        return new Promise((s, f) => f(e));
+        return Promise.reject(e);
       }
     });
   };
@@ -121,7 +121,7 @@ class IzanamiConfigClient {
     const dottyKey = pattern.replace(/:/g, ".");
     const url = this.conf.host + "/api/tree/configs?pattern=" + columnPattern;
     if (this.conf.env === 'DEV') {
-      return new Promise((s, f) => s(_.get(this.conf.fallbackConfig, dottyKey)));
+      return Promise(_.get(this.conf.fallbackConfig, dottyKey));
     }
     return fetch(url, {
       method: 'GET',
@@ -137,7 +137,7 @@ class IzanamiConfigClient {
           return deepmerge(this.conf.fallbackConfig, f)
         });
       } catch(e) {
-        return new Promise((s, f) => f(e));
+        return Promise.reject(e);
       }
     });
   };
@@ -157,7 +157,7 @@ class IzanamiExperimentsClient {
     const url = this.conf.host + "/api/experiments/" + columnKey;
     if (this.conf.env === 'DEV') {
       const value = _.get(this.conf.fallbackConfig, dottyKey) || {};
-      return new Promise((s, f) => s(value.active || {}));
+      return Promise.resolve(value.active || {});
     }
     return fetch(url, {
       method: 'GET',
@@ -178,10 +178,10 @@ class IzanamiExperimentsClient {
         } else if (r.status === 404) {
           return _.get(this.conf.fallbackConfig, dottyKey) || {};
         } else {
-          return new Promise((s, f) => f({ message: 'Bad response', response: r }));
+          return Promise.reject({ message: 'Bad response', response: r });
         }
       } catch(e) {
-        return new Promise((s, f) => f(e));
+        return Promise.reject(e);
       }
     });
   };
@@ -191,7 +191,7 @@ class IzanamiExperimentsClient {
     const dottyKey = pattern.replace(/:/g, ".");
     const url = this.conf.host + "/api/tree/experiments?pattern=" + columnPattern + "&clientId=" + clientId;
     if (this.conf.env === 'DEV') {
-      return new Promise((s, f) => s(_.get(this.conf.fallbackConfig, dottyKey)));
+      return Promise.resolve(_.get(this.conf.fallbackConfig, dottyKey));
     }
     return fetch(url, {
       method: 'GET',
@@ -207,7 +207,7 @@ class IzanamiExperimentsClient {
           return deepmerge(this.conf.fallbackConfig, f)
         });
       } catch(e) {
-        return new Promise((s, f) => f(e));
+        return Promise.reject(e);
       }
     });
   };
@@ -218,7 +218,7 @@ class IzanamiExperimentsClient {
     const url = this.conf.host + "/api/experiments/" + columnKey + "/variant?clientId=" + clientId
     if (this.conf.env === 'DEV') {
       const value = _.get(this.conf.fallbackConfig, dottyKey) || {};
-      return new Promise((s, f) => s(value.active || {}));
+      return Promise.resolve(value.active || {});
     }
     return fetch(url, {
       method: 'GET',
@@ -234,12 +234,12 @@ class IzanamiExperimentsClient {
           return r.json();
         } else if (r.status === 404) {
           const value = _.get(this.conf.fallbackConfig, dottyKey) || {};
-          return new Promise((s, f) => s(value.active || {}));
+          return Promise.resolve(value.active || {});
         } else {
-          return new Promise((s, f) => f({ message: 'Bad response', response: r }));
+          return Promise.reject({ message: 'Bad response', response: r });
         }
       } catch(e) {
-        return new Promise((s, f) => f(e));
+        return Promise.reject(e);
       }
     });
   }
@@ -248,7 +248,7 @@ class IzanamiExperimentsClient {
     const columnKey = key.replace(/\./g, ":");
     const url = this.conf.host + "/api/experiments/" + columnKey + "/displayed?clientId=" + clientId;
     if (this.conf.env === 'DEV') {
-      return new Promise((s, f) => s({}));
+      return Promise.resolve({});
     }
     return fetch(url, {
       method: 'POST',
@@ -264,10 +264,10 @@ class IzanamiExperimentsClient {
         if (r.status === 200 || r.state === 404) {
           return r;
         } else {
-          return new Promise((s, f) => f({ message: 'Bad response', response: r }));
+          return Promise.reject({ message: 'Bad response', response: r });
         }
       } catch(e) {
-        return new Promise((s, f) => f(e));
+        return Promise.reject(e);
       }
     });
   }
@@ -276,7 +276,7 @@ class IzanamiExperimentsClient {
     const columnKey = key.replace(/\./g, ":");
     const url = this.conf.host + "/api/experiments/" + columnKey + "/won?clientId=" + clientId;
     if (this.conf.env === 'DEV') {
-      return new Promise((s, f) => s({}));
+      return Promise.resolve({});
     }
     return fetch(url, {
       method: 'POST',
@@ -292,10 +292,10 @@ class IzanamiExperimentsClient {
         if (r.status === 200 || r.state === 404) {
           return r;
         } else {
-          return new Promise((s, f) => f({ message: 'Bad response', response: r }));
+          return Promise.reject({ message: 'Bad response', response: r });
         }
       } catch(e) {
-        return new Promise((s, f) => f(e));
+        return Promise.reject(e);
       }
     });
   }
@@ -323,15 +323,12 @@ module.exports = {
     const { featureClient, configClient, experimentsClient, app, sessionPath, experimentWonPath, experimentDisplayedPath, path } = config;
 
     app.get(sessionPath || '/api/me', (req, res) => {
-      new Promise((s, f) => s({})).then(() => {
-        (!!featureClient ? featureClient.features(path, { user: req.user_email }) : new Promise((s, f) => s({}))).then(features => {
-          (!!experimentsClient ? experimentsClient.experiments(path, req.user_email) : new Promise((s, f) => s({}))).then(experiments => {
-            (!!configClient ? configClient.configs(path) : new Promise((s, f) => s({}))).then(configurations => {
-              res.send({ experiments, features, configurations });
-            });
-          });
-        });
-      });
+        const [features, experiments, configurations] = Promise.all([
+            (!!featureClient ? featureClient.features(path, { user: req.user_email }) : {}),
+            (!!experimentsClient ? experimentsClient.experiments(path, req.user_email) : {}),
+            (!!configClient ? configClient.configs(path) : {})
+        ]);
+        res.send({ experiments, features, configurations });
     });
 
     app.post(experimentWonPath || '/api/experiments/won', (req, res) => {

--- a/izanami-documentation/src/main/paradox/clients/node.md
+++ b/izanami-documentation/src/main/paradox/clients/node.md
@@ -1,203 +1,218 @@
 # Node js client
 
-## Install 
+## Install
 
 ```bash
 npm install izanami-node
 ```
 
-## Import 
+## Import
 
 ```javascript
-const Izanami = require('izanami-node');
+const Izanami = require("izanami-node");
 ```
 
+## Usage
 
-## Usage 
-
-The node client expose conveniant methods to call Izanami. 
+The node client expose conveniant methods to call Izanami.
 
 ### Configure the client:
- 
+
 ```javascript
-const izanamicConfig = Object.assign({}, Izanami.defaultConfig, {
-  host: 'http://localhost:9000',
-  clientId: process.env.CLIENT_ID || 'xxxx',
-  clientSecret: process.env.CLIENT_SECRET || 'xxxx',
+const izanamiConfig = Object.assign({}, Izanami.defaultConfig, {
+  host: "http://localhost:9000",
+  clientId: process.env.CLIENT_ID || "xxxx",
+  clientSecret: process.env.CLIENT_SECRET || "xxxx",
 });
 
 // Get a configs client
-const configClient = Izanami.configClient(izanamicConfig);
-// Get a feature client 
-const featureClient = Izanami.featureClient(izanamicConfig);
-// Get a experiments client 
-const experimentsClient = Izanami.experimentsClient(izanamicConfig);
+const configClient = Izanami.configClient(izanamiConfig);
+// Get a feature client
+const featureClient = Izanami.featureClient(izanamiConfig);
+// Get a experiments client
+const experimentsClient = Izanami.experimentsClient(izanamiConfig);
 ```
 
-### Configs 
+### Configs
 
-### Get a config 
+### Get a config
 
 ```javascript
-configClient.config("my.config.id").then(config => {
-  console.log('The config is ', config);
+configClient.config("my.config.id").then((config) => {
+  console.log("The config is ", config);
   tree.should.be.deep.equal({
-      "value": "test"
-  })
+    value: "test",
+  });
 });
 ```
+
 #### Get the configs tree
 
 ```javascript
-configClient.configs("my.config.*").then(tree => {
+configClient.configs("my.config.*").then((tree) => {
   tree.should.be.deep.equal({
-      "my": {
-        "config": {
-          "id": {
-            "value": "test"
+    my: {
+      config: {
+        id: {
+          value: "test",
+        },
+        id2: {
+          another: {
+            value: "a value",
           },
-          "id2": {
-            "another": {
-              "value": "a value"
-            }
-          }
-        }
-      }
-    });
+        },
+      },
+    },
+  });
 });
 ```
- 
 
 ### Features
- 
+
 #### Check a feature
 
 ```javascript
-featureClient.checkFeature("my.feature.id").then(active => {
-  console.log('The feature is ', active);
+featureClient.checkFeature("my.feature.id").then((active) => {
+  console.log("The feature is ", active);
 });
 ```
 
-Or with a context: 
- 
+Or with a context:
+
 ```javascript
-featureClient.checkFeature("my.feature.id", {client: "ragnard.lodbrock@gmail.com"}).then(active => {
-  console.log('The feature is ', active);
-});
-```
-#### Get the features tree 
- 
-```javascript
-featureClient.features("my.feature.*").then(tree => {
-  tree.should.be.deep.equal({
-    "my": {
-      "feature": {
-        "id": {
-          "active": true
-        },
-        "id2": {
-          "active": false
-        }
-      }
-    }
+featureClient
+  .checkFeature("my.feature.id", { client: "ragnard.lodbrock@gmail.com" })
+  .then((active) => {
+    console.log("The feature is ", active);
   });
-});
 ```
- 
-Or with a context: 
+
+#### Get the features tree
 
 ```javascript
-featureClient.features("my.feature.*", {client: "ragnard.lodbrock@gmail.com"}).then(tree => {
+featureClient.features("my.feature.*").then((tree) => {
   tree.should.be.deep.equal({
-    "my": {
-      "feature": {
-        "id": {
-          "active": true
+    my: {
+      feature: {
+        id: {
+          active: true,
         },
-        "id2": {
-          "active": false
-        }
-      }
-    }
+        id2: {
+          active: false,
+        },
+      },
+    },
   });
 });
 ```
 
-### Experiments  
+Or with a context:
+
+```javascript
+featureClient
+  .features("my.feature.*", { client: "ragnard.lodbrock@gmail.com" })
+  .then((tree) => {
+    tree.should.be.deep.equal({
+      my: {
+        feature: {
+          id: {
+            active: true,
+          },
+          id2: {
+            active: false,
+          },
+        },
+      },
+    });
+  });
+```
+
+### Experiments
 
 #### Get an experiment
- 
+
 ```javascript
-experimentsClient.experiment("my.experiment.id").then(experiment => {
-  //Empty json if the experiment doesn't exists 
-  console.log('The experiment is ', experiment);
+experimentsClient.experiment("my.experiment.id").then((experiment) => {
+  //Empty json if the experiment doesn't exists
+  console.log("The experiment is ", experiment);
 });
 ```
 
 #### Get experiments as tree
- 
+
 ```javascript
-experimentsClient.experiments("my.experiment.*", "ragnard.lodbrock@gmail.com").then(tree => {
-  //Empty json if the experiment doesn't exists 
-  console.log('The experiment is ', experiment);
-  tree.should.be.deep.equal({
-    "my": {
-      "experiment": {
-        "id": {
-          "variant": "A"
+experimentsClient
+  .experiments("my.experiment.*", "ragnard.lodbrock@gmail.com")
+  .then((tree) => {
+    //Empty json if the experiment doesn't exists
+    console.log("The experiment is ", experiment);
+    tree.should.be.deep.equal({
+      my: {
+        experiment: {
+          id: {
+            variant: "A",
+          },
+          id2: {
+            variant: "B",
+          },
         },
-        "id2": {
-          "variant": "B"
-        }
-      }
-    }
-  })
-});
+      },
+    });
+  });
 ```
 
 #### Get a variant
- 
+
 ```javascript
-experimentsClient.variantFor("my.experiment.id", "ragnard.lodbrock@gmail.com").then(variant => {
-  //Empty json if the variant doesn't exists 
-  console.log('The variant is ', variant);
-});
+experimentsClient
+  .variantFor("my.experiment.id", "ragnard.lodbrock@gmail.com")
+  .then((variant) => {
+    //Empty json if the variant doesn't exists
+    console.log("The variant is ", variant);
+  });
 ```
 
 #### Mark variant displayed
- 
-```javascript
-experimentsClient.displayed("my.experiment.id", "ragnard.lodbrock@gmail.com").then(__ => {
-  console.log('The variant is marked displayed');
-});
-```
- 
-#### Mark variant won  
 
 ```javascript
-experimentsClient.won("my.experiment.id", "ragnard.lodbrock@gmail.com").then(__ => {
-  console.log('The variant is marked won');
-});
+experimentsClient
+  .displayed("my.experiment.id", "ragnard.lodbrock@gmail.com")
+  .then((__) => {
+    console.log("The variant is marked displayed");
+  });
 ```
 
+#### Mark variant won
 
-## Express proxy 
+```javascript
+experimentsClient
+  .won("my.experiment.id", "ragnard.lodbrock@gmail.com")
+  .then((__) => {
+    console.log("The variant is marked won");
+  });
+```
 
-You use express as a proxy to expose Izanami to the client side. 
+## Express proxy
+
+You use express as a proxy to expose Izanami to the client side.
+You can customize the api endpoints with the `sessionPath`, `experimentsDisplayedPath` and `experimentsWonPath`
+config options.
+
+The feature and experiments clients context and id are extracted from the request; you can extend it using your own methods with `featureContextFromRequest` and `experimentsIdFromRequest`.
 
 ```javascript
 const app = express();
 
 Izanami.expressProxy({
-  sessionPath: '/api/izanami', // default '/api/me'
+  sessionPath: "/api/izanami", // default '/api/me'
+  experimentsDisplayedPath, // default: '/api/experiments/displayed'
+  experimentsWonPath, // default: '/api/experiments/won'
   featureClient, // Optional
+  featureContextFromRequest, //default: (req) => ({user: req.user_email})
   experimentsClient, // Optional
+  experimentsIdFromRequest, //default: (req) => (req.user_email)
   configClient, // Optional
-  app, // Express app 
-  path: 'my.namespace.*' // The pattern to filter experiments, configs and features
+  app, // Express app
+  path: "my.namespace.*", // The pattern to filter experiments, configs and features
 });
-
 ```
-
-
-


### PR DESCRIPTION
The main benefit here is that we fire all the requests to the three are not so sequential and may run in parallel.

I added some configurability to the express proxy, to make it easier to integrate in existing apps