### PR TITLE
#671 : allows to set oauth2.claims with env variable

### DIFF
--- a/docs/manual/authprovider/index.html
+++ b/docs/manual/authprovider/index.html
@@ -298,6 +298,11 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
       <td>Oauth2 scope of the requested user info </td>
     </tr>
     <tr>
+      <td><code>izanami.oauth2.claims</code> </td>
+      <td><code>OAUTH2_CLAIMS</code> </td>
+      <td>Oauth2 claims of the requested user info </td>
+    </tr>
+    <tr>
       <td><code>izanami.oauth2.readProfileFromToken</code> </td>
       <td><code>OAUTH2_READ_FROM_TOKEN</code> </td>
       <td>Should the user be read from token </td>

--- a/docs/manual/settings/settings.html
+++ b/docs/manual/settings/settings.html
@@ -1146,6 +1146,11 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
       <td>Oauth2 scope of the requested user info </td>
     </tr>
     <tr>
+      <td><code>izanami.oauth2.claims</code> </td>
+      <td><code>OAUTH2_CLAIMS</code> </td>
+      <td>Oauth2 claims of the requested user info </td>
+    </tr>
+    <tr>
       <td><code>izanami.oauth2.readProfileFromToken</code> </td>
       <td><code>OAUTH2_READ_FROM_TOKEN</code> </td>
       <td>Should the user be read from token </td>

--- a/izanami-server/conf/application.conf
+++ b/izanami-server/conf/application.conf
@@ -324,6 +324,7 @@ izanami {
     loginUrl = ${?OAUTH2_LOGIN_URL}
     logoutUrl = "https://localhost:8943/auth/realms/master/protocol/openid-connect/logout"
     logoutUrl = ${?OAUTH2_LOGOUT_URL}
+    claims = ${?OAUTH2_CLAIMS}
     clientId = "izanami"
     clientId = ${?OAUTH2_CLIENT_ID}
 //    clientSecret = "secret"


### PR DESCRIPTION
Claims parameter is not allowed by Google OAuth2 and must be empty

With this fix, we can use environement variable OAUTH2_CLAIMS to set as empty the request claims.