### PR TITLE
#673 fix oauth2 callback uri

### DIFF
--- a/izanami-server/app/controllers/OAuthController.scala
+++ b/izanami-server/app/controllers/OAuthController.scala
@@ -32,7 +32,7 @@ class OAuthController(_env: Env, mayBeOauth2Config: Option[Oauth2Config], cc: Co
         val claims       = Option(openIdConnectConfig.claims).filterNot(_.isEmpty).map(v => s"claims=$v&").getOrElse("")
         val queryParam   = if (openIdConnectConfig.useCookie) "" else s"?desc=izanami"
         val redirectUri = if (_env.baseURL.startsWith("http")) {
-          s"${_env.baseURL}/${controllers.routes.OAuthController.appCallback().url}${queryParam}"
+          s"${_env.baseURL}${controllers.routes.OAuthController.appCallback().url}${queryParam}"
         } else {
           s"${controllers.routes.OAuthController.appCallback().absoluteURL()}${queryParam}"
         }
@@ -57,7 +57,7 @@ class OAuthController(_env: Env, mayBeOauth2Config: Option[Oauth2Config], cc: Co
     mayBeOauth2Config match {
       case Some(openIdConnectConfig) =>
         Oauth2Service
-          .paCallback(s"${_env.baseURL}/", openIdConnectConfig)
+          .paCallback(s"${_env.baseURL}", openIdConnectConfig)
           .map { user =>
             Redirect(controllers.routes.HomeController.index())
               .withCookies(Cookie(name = _env.cookieName, value = User.buildToken(user, _config.issuer, algorithm)))

--- a/izanami-server/app/domains/auth/auth.scala
+++ b/izanami-server/app/domains/auth/auth.scala
@@ -263,7 +263,7 @@ package object auth {
         val clientSecret = authConfig.clientSecret.map(_.trim).filterNot(_.isEmpty)
         val queryParam   = if (authConfig.useCookie) "" else s"?desc=izanami"
         val redirectUri = if (baseURL.startsWith("http")) {
-          s"${baseURL}/${controllers.routes.OAuthController.appCallback().url}${queryParam}"
+          s"${baseURL}${controllers.routes.OAuthController.appCallback().url}${queryParam}"
         } else {
           s"${controllers.routes.OAuthController.appCallback().absoluteURL()}${queryParam}"
         }


### PR DESCRIPTION
#673 : remove duplicate slash in oauth2 callback uri to work correctly with Google OAuth2.
PS : I am not sure if it can cause regression when using Izanami with other identity providers...