### PR TITLE
#687 fix contextPath when using baseURL with absolute URL

### DIFF
--- a/izanami-server/app/views/index.scala.html
+++ b/izanami-server/app/views/index.scala.html
@@ -21,7 +21,11 @@
     }
     <div id="app"></div>
     <script type="application/javascript">
+        @if(_env.baseURL.startsWith("http")) {
+        window.__contextPath = '';
+        } else {
         window.__contextPath = '@_env.baseURL';
+        }
         Izanami.init(document.getElementById("app"), '@logout', @confirmationDialog, '@userManagementMode', @enabledApikeyManagement, JSON.parse('@Html(Json.stringify(user))'));
     </script>
     <script>'Version: @version - Commit Id: @gitCommitId'</script>


### PR DESCRIPTION
Fixes #687
When using baseURL parameter with an absolute URL, links in UI must not append the baseURL in routes.