### PR TITLE
Remove events from VariantResult model

### DIFF
--- a/izanami-server/app/domains/abtesting/events/events.scala
+++ b/izanami-server/app/domains/abtesting/events/events.scala
@@ -146,7 +146,7 @@ package object events {
                   won,
                   transformation,
                   Some(
-                    VariantResult(Some(evt.variant), displayed, won, transformation, users = ids.size, Seq(newEvent))
+                    VariantResult(Some(evt.variant), displayed, won, transformation, users = ids.size)
                   )
                 )
               )
@@ -156,8 +156,8 @@ package object events {
           }
         }
         .fold(VariantResult()) {
-          case (acc, (d, w, t, Some(r))) =>
-            r.copy(events = acc.events ++ r.events, displayed = d, won = w, transformation = t)
+          case (_, (d, w, t, Some(r))) =>
+            r.copy(displayed = d, won = w, transformation = t)
           case (acc, (d, w, t, None)) =>
             acc.copy(displayed = d, won = w, transformation = t)
         }

--- a/izanami-server/app/domains/abtesting/events/impl/ExperimentVariantEventElastic6Service.scala
+++ b/izanami-server/app/domains/abtesting/events/impl/ExperimentVariantEventElastic6Service.scala
@@ -452,14 +452,13 @@ class ExperimentVariantEventElastic6Service(
       val users = Source.future(countUsers(experimentId, variantId))
 
       events.zip(won).zip(displayed).zip(users).map {
-        case (((e, w), d), u) =>
+        case (((_, w), d), u) =>
           VariantResult(
             variant = Some(variant),
             displayed = d,
             won = w,
             users = u.toDouble,
-            transformation = if (d != 0) (w * 100.0) / d else 0.0,
-            events = e
+            transformation = if (d != 0) (w * 100.0) / d else 0.0
           )
       }
     }

--- a/izanami-server/app/domains/abtesting/events/impl/ExperimentVariantEventElastic7Service.scala
+++ b/izanami-server/app/domains/abtesting/events/impl/ExperimentVariantEventElastic7Service.scala
@@ -446,14 +446,13 @@ class ExperimentVariantEventElastic7Service(
       val users = Source.future(countUsers(experimentId, variantId))
 
       events.zip(won).zip(displayed).zip(users).map {
-        case (((e, w), d), u) =>
+        case (((_, w), d), u) =>
           VariantResult(
             variant = Some(variant),
             displayed = d,
             won = w,
             users = u.toDouble,
-            transformation = if (d != 0) (w * 100.0) / d else 0.0,
-            events = e
+            transformation = if (d != 0) (w * 100.0) / d else 0.0
           )
       }
     }

--- a/izanami-server/app/domains/abtesting/experiments.scala
+++ b/izanami-server/app/domains/abtesting/experiments.scala
@@ -131,8 +131,7 @@ package object abtesting {
       displayed: Long = 0,
       won: Long = 0,
       transformation: Double = 0,
-      users: Double = 0,
-      events: Seq[ExperimentResultEvent] = Seq.empty
+      users: Double = 0
   )
 
   case class ExperimentResultEvent(


### PR DESCRIPTION
https://github.com/MAIF/izanami/issues/706

This is probably just the beginning. In order to really fix this issue the  experiment result query must be offloaded to the store. In the current solution all events are downloaded into memory and iterated on the server, but this becomes very expensive when there are millions of events.

The experiment result is generated in the implementations of this trait
https://github.com/maif/izanami/blob/master/izanami-server/app/domains/abtesting/events/events.scala#L193-L195