### PR TITLE
Fix for Dockerfile smell DL3015

### DIFF
--- a/izanami-benchmarks/client/Dockerfile
+++ b/izanami-benchmarks/client/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 RUN mkdir -p /client
 WORKDIR /client
 COPY . /client
-RUN apt-get update -y && apt-get install curl tar build-essential libssl-dev git -y
+RUN apt-get update -y && apt-get install --no-install-recommends curl tar build-essential libssl-dev git -y
 RUN git clone https://github.com/giltene/wrk2.git wrk2
 RUN cd wrk2 && make && cp wrk /usr/local/bin
 RUN curl -O https://dl.google.com/go/go1.10.2.linux-amd64.tar.gz


### PR DESCRIPTION
Hi!
The Dockerfile placed at "izanami-benchmarks/client/Dockerfile" contains the best practice violation [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3015 occurs when the apt tool is used to install packages without the "--no-install-recommends" flag. This flag is recommended to be used to avoid installing additional packages not explicitly requested.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the "--no-install-recommends" flag is added to the apt-get install command.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance