### PR TITLE
feat: Track stale features

### DIFF
--- a/app/fr/maif/izanami/application.scala
+++ b/app/fr/maif/izanami/application.scala
@@ -4,9 +4,9 @@ import com.softwaremill.macwire.wire
 import controllers.{Assets, AssetsComponents}
 import fr.maif.izanami.env.Env
 import fr.maif.izanami.errors.IzanamiHttpErrorHandler
-import fr.maif.izanami.events.EventService
+import fr.maif.izanami.services.FeatureService
 import fr.maif.izanami.v1.WasmManagerClient
-import fr.maif.izanami.web.{ClientApiKeyAction, _}
+import fr.maif.izanami.web._
 import play.api.ApplicationLoader.Context
 import play.api._
 import play.api.http.{DefaultHttpFilters, HttpErrorHandler}
@@ -15,11 +15,10 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.filters.HttpFiltersComponents
 import play.filters.cors.{CORSConfig, CORSFilter}
-import play.filters.csp.{CSPComponents, CSPFilter, CSPResultProcessor}
+import play.filters.csp.CSPComponents
 import play.filters.csrf.CSRFFilter
 import play.filters.gzip.GzipFilterComponents
-import play.filters.headers.{SecurityHeadersConfig, SecurityHeadersFilter}
-import play.filters.https.{RedirectHttpsComponents, RedirectHttpsConfiguration, RedirectHttpsFilter}
+import play.filters.https.RedirectHttpsComponents
 import router.Routes
 
 import scala.concurrent.duration.DurationInt
@@ -76,6 +75,8 @@ class IzanamiComponentsInstances(
   lazy val webhookAuthAction                = wire[WebhookAuthActionFactory]
   lazy val validatePasswordAction           = wire[ValidatePasswordActionFactory]
   lazy val tokenOrCookieAuthActionForTenant = wire[PersonnalAccessTokenTenantAuthActionFactory]
+
+  lazy val featureService = wire[FeatureService]
 
   lazy val featureController              = wire[FeatureController]
   lazy val tenantController               = wire[TenantController]

--- a/app/fr/maif/izanami/application.scala
+++ b/app/fr/maif/izanami/application.scala
@@ -4,7 +4,7 @@ import com.softwaremill.macwire.wire
 import controllers.{Assets, AssetsComponents}
 import fr.maif.izanami.env.Env
 import fr.maif.izanami.errors.IzanamiHttpErrorHandler
-import fr.maif.izanami.services.FeatureService
+import fr.maif.izanami.services.{FeatureService, StaleFeatureService}
 import fr.maif.izanami.v1.WasmManagerClient
 import fr.maif.izanami.web._
 import play.api.ApplicationLoader.Context
@@ -76,9 +76,11 @@ class IzanamiComponentsInstances(
   lazy val validatePasswordAction           = wire[ValidatePasswordActionFactory]
   lazy val tokenOrCookieAuthActionForTenant = wire[PersonnalAccessTokenTenantAuthActionFactory]
 
-  lazy val featureService = wire[FeatureService]
+  lazy val featureService      = wire[FeatureService]
+  lazy val staleFeatureService = wire[StaleFeatureService]
 
   lazy val featureController              = wire[FeatureController]
+  lazy val staleFeatureController         = wire[StaleFeatureController]
   lazy val tenantController               = wire[TenantController]
   lazy val projectController              = wire[ProjectController]
   lazy val tagController                  = wire[TagController]

--- a/app/fr/maif/izanami/datastores/FeatureCallsDatastore.scala
+++ b/app/fr/maif/izanami/datastores/FeatureCallsDatastore.scala
@@ -4,15 +4,24 @@ import fr.maif.izanami.env.Env
 import fr.maif.izanami.errors.IzanamiError
 import fr.maif.izanami.utils.Datastore
 import fr.maif.izanami.utils.syntax.implicits.BetterJsValue
+import fr.maif.izanami.env.pgimplicits.EnhancedRow
 import play.api.libs.json.JsValue
 
+import java.time.{Instant, ZoneOffset}
 import scala.concurrent.Future
 
-class FeatureCallsDatastore(val env: Env) extends Datastore{
+class FeatureCallsDatastore(val env: Env) extends Datastore {
+
   private type FeatureId = String
-  def registerCall(tenant: String, key: String, valuesByFeature: Map[FeatureId, JsValue]): Future[Either[IzanamiError, Unit]] = {
-    env.postgresql.queryOne(
-      query = s"""
+
+  def registerCall(
+      tenant: String,
+      key: String,
+      valuesByFeature: Map[FeatureId, JsValue]
+  ): Future[Either[IzanamiError, Unit]] = {
+    env.postgresql
+      .queryOne(
+        query = s"""
          |INSERT INTO feature_calls(feature, apikey, value) VALUES (unnest($$1::text[]), $$2, unnest($$3::jsonb[]))
          |""".stripMargin,
         params = List(
@@ -21,8 +30,26 @@ class FeatureCallsDatastore(val env: Env) extends Datastore{
           valuesByFeature.values.map(json => json.vertxJsValue).toArray
         ),
         schemas = Set(tenant)
-    ){r => Some(())}
+      ) { r => Some(()) }
       .map(_ => Right(()))
+      .recover(env.postgresql.pgErrorPartialFunction.andThen(err => Left(err)))
+  }
+
+  def findFeatureWithoutCallSince(tenant: String, since: Instant): Future[Either[IzanamiError, List[String]]] = {
+    env.postgresql
+      .queryAll(
+        query = s"""
+         |SELECT feature
+         |FROM feature_calls
+         |GROUP BY feature
+         |HAVING MAX(date) < $$1
+         |""".stripMargin,
+        params = List(
+          since.atOffset(ZoneOffset.UTC)
+        ),
+        schemas = Set(tenant)
+      ) { r => r.optString("feature") }
+      .map(features => Right(features))
       .recover(env.postgresql.pgErrorPartialFunction.andThen(err => Left(err)))
   }
 }

--- a/app/fr/maif/izanami/datastores/FeatureCallsDatastore.scala
+++ b/app/fr/maif/izanami/datastores/FeatureCallsDatastore.scala
@@ -39,7 +39,7 @@ class FeatureCallsDatastore(val env: Env) extends Datastore {
     env.postgresql
       .queryAll(
         query = s"""
-         |SELECT feature
+         |SELECT feature, MAX(date) AS last_call
          |FROM feature_calls
          |GROUP BY feature
          |HAVING MAX(date) < $$1

--- a/app/fr/maif/izanami/datastores/ProjectsDatastore.scala
+++ b/app/fr/maif/izanami/datastores/ProjectsDatastore.scala
@@ -218,7 +218,11 @@ class ProjectsDatastore(val env: Env) extends Datastore {
          |          WHERE ft.feature = f.id
          |          GROUP BY ft.tag
          |        )
-         |      ), 'wasmConfig', f.script_config))::jsonb)
+         |      ), 'wasmConfig', f.script_config,
+         |      'lastCall', (SELECT max(fc.date)
+         |                   from feature_calls fc
+         |                   where fc.feature = f.id)
+         |      ))::jsonb)
          |      FILTER (WHERE f.id IS NOT NULL), '[]'
          |  ) as "features"
          |from projects p

--- a/app/fr/maif/izanami/models/FeatureStrategies.scala
+++ b/app/fr/maif/izanami/models/FeatureStrategies.scala
@@ -1,0 +1,42 @@
+package fr.maif.izanami.models
+
+import fr.maif.izanami.env.Env
+import fr.maif.izanami.errors.IzanamiError
+import play.api.libs.json.JsValue
+
+import scala.concurrent.Future
+
+case class FeatureStrategies(strategies: Map[String, CompleteFeature]) {
+
+  def evaluate(requestContext: RequestContext, env: Env): Future[Either[IzanamiError, EvaluatedCompleteFeature]] = {
+    val context = requestContext.contextAsString
+    val strategyToUse = if (context.isBlank) {
+      strategies("")
+    } else {
+      strategies
+        .filter { case (ctx, f) => context.startsWith(ctx) }
+        .toSeq
+        .sortWith {
+          case ((c1, _), (c2, _)) if c1.length < c2.length => false
+          case _ => true
+        }
+        .headOption
+        .map(_._2)
+        .getOrElse(strategies(""))
+    }
+    strategyToUse.value(requestContext, env).map(either => either.map(v => EvaluatedCompleteFeature(this, v)))(env.executionContext)
+  }
+
+}
+
+case class EvaluatedCompleteFeature(featureStrategies: FeatureStrategies, result: JsValue) {
+  def baseFeature: CompleteFeature = {
+    featureStrategies.strategies("")
+  }
+}
+
+case object FeatureStrategies {
+  def apply(f: CompleteFeature): FeatureStrategies = {
+    FeatureStrategies(Map("" -> f))
+  }
+}

--- a/app/fr/maif/izanami/services/FeatureService.scala
+++ b/app/fr/maif/izanami/services/FeatureService.scala
@@ -1,0 +1,113 @@
+package fr.maif.izanami.services
+
+import fr.maif.izanami.env.Env
+import fr.maif.izanami.errors.{IncorrectKey, IzanamiError}
+import fr.maif.izanami.models._
+import fr.maif.izanami.utils.Helpers
+import fr.maif.izanami.utils.syntax.implicits.BetterSyntax
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FeatureService(env: Env) {
+
+  implicit val ec: ExecutionContext = env.executionContext
+
+  /**
+   * Evaluates features for a given request context.
+   *
+   * @param conditions whether to return the activation condition in the evaluation result
+   * @param requestContext the request context
+   * @param featureRequest the feature request
+   * @param clientId the client id
+   * @param clientSecret the client secret
+   * @return a future of either an error or a sequence of evaluated features
+   */
+  def evaluateFeatures(
+      conditions: Boolean,
+      requestContext: RequestContext,
+      featureRequest: FeatureRequest,
+      clientId: String,
+      clientSecret: String
+  ): Future[Either[IzanamiError, Seq[EvaluatedCompleteFeature]]] = {
+
+    val features = retrieveFeatureFromQuery(conditions, featureRequest, clientId, clientSecret)
+    features.flatMap {
+      case Left(error) => Left(error).future
+      case Right(f)    => evaluate(f, requestContext, env)
+    }
+
+  }
+
+  private def retrieveFeatureFromQuery(
+      conditions: Boolean,
+      featureRequest: FeatureRequest,
+      clientId: String,
+      clientSecret: String
+  ): Future[Either[IzanamiError, Seq[FeatureStrategies]]] = {
+
+    val futureMaybeTenant = ApiKey
+      .extractTenant(clientId)
+      .map(t => Future.successful(Some(t)))
+      .getOrElse(env.datastores.apiKeys.findLegacyKeyTenant(clientId))
+
+    val result = futureMaybeTenant.flatMap {
+      case None         => Left(IncorrectKey()).future
+      case Some(tenant) => {
+        if (conditions) {
+          val futureFeaturesByProject =
+            env.datastores.features.doFindByRequestForKey(tenant, featureRequest, clientId, clientSecret, true)
+          futureFeaturesByProject.map {
+            case Left(error)                                             => Left(error)
+            case Right(featuresByProjects) if featuresByProjects.isEmpty => Left(IncorrectKey())
+            case Right(featuresByProjects)                               => {
+              val strategies = featuresByProjects.toSeq.flatMap {
+                case (_, features) => {
+                  features.map {
+                    case (_, featureAndContexts) => {
+                      // TODO turn featureAndContext into instance of FeatureStrategies
+                      val strategyByCtx = featureAndContexts.map {
+                        case (Some(ctx), feat) => (ctx, feat)
+                        case (None, feat)      => ("", feat)
+                      }.toMap
+
+                      FeatureStrategies(strategyByCtx)
+                    }
+                  }
+                }
+              }
+              Right(strategies)
+            }
+          }
+        } else {
+          val futureFeaturesByProject = env.datastores.features.findByRequestForKey(
+            tenant,
+            featureRequest,
+            clientId,
+            clientSecret
+          )
+
+          futureFeaturesByProject.map {
+            case Left(error)                                             => Left(error)
+            case Right(featuresByProjects) if featuresByProjects.isEmpty => Left(IncorrectKey())
+            case Right(featuresByProjects)                               => {
+              // TODO turn return type of findByRequestForKey to FeatureStrategies so that we don't have to use
+              //  an empty context here
+              val strategies = featuresByProjects.values.flatten.map(v => FeatureStrategies(v)).toSeq
+              Right(strategies)
+            }
+          }
+        }
+      }
+    }
+    result
+  }
+
+  private def evaluate(
+      features: Seq[FeatureStrategies],
+      requestContext: RequestContext,
+      env: Env
+  ): Future[Either[IzanamiError, Seq[EvaluatedCompleteFeature]]] = {
+    val evaluatedFeatures = Future.sequence(features.map(f => f.evaluate(requestContext, env)))
+    evaluatedFeatures.map(Helpers.sequence(_))
+  }
+}

--- a/app/fr/maif/izanami/services/StaleFeatureService.scala
+++ b/app/fr/maif/izanami/services/StaleFeatureService.scala
@@ -1,0 +1,18 @@
+package fr.maif.izanami.services
+
+import fr.maif.izanami.env.Env
+import fr.maif.izanami.errors.IzanamiError
+
+import java.time.{Duration, Instant}
+import scala.concurrent.Future
+
+class StaleFeatureService(env: Env) {
+
+  private val featureCalls = env.datastores.featureCalls
+
+  def reportStaleFeatures(tenant: String, delay: Duration): Future[Either[IzanamiError, List[String]]] = {
+    val nowMinusDelay = Instant.now().minus(delay)
+    featureCalls.findFeatureWithoutCallSince(tenant, nowMinusDelay)
+  }
+
+}

--- a/app/fr/maif/izanami/v1/OldFeatures.scala
+++ b/app/fr/maif/izanami/v1/OldFeatures.scala
@@ -13,8 +13,7 @@ import play.api.libs.json.Reads.{localDateTimeReads, localTimeReads, max, min}
 import play.api.libs.json._
 
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDateTime, LocalTime, ZoneId}
-import scala.runtime.RichBoolean
+import java.time.{Instant, LocalDateTime, LocalTime, ZoneId}
 
 sealed trait OldFeature {
   def id: String
@@ -25,7 +24,8 @@ sealed trait OldFeature {
   def toFeature(
       project: String,
       zone: ZoneId,
-      globalScriptById: Map[String, OldGlobalScript]
+      globalScriptById: Map[String, OldGlobalScript],
+      lastCall: Option[Instant]
   ): Either[String, (CompleteFeature, Option[OldScript])] = {
     this match {
       case OldDefaultFeature(id, name, enabled, description, tags, _)                   =>
@@ -38,7 +38,8 @@ sealed trait OldFeature {
               project = project,
               condition = All,
               description = description.getOrElse(""),
-              tags = tags
+              tags = tags,
+              lastCall = lastCall
             ),
             None
           )
@@ -57,7 +58,8 @@ sealed trait OldFeature {
                 timezone = zone
               ),
               description = description.getOrElse(""),
-              tags = tags
+              tags = tags,
+              lastCall = lastCall,
             ),
             None
           )
@@ -72,7 +74,8 @@ sealed trait OldFeature {
               project = project,
               condition = DateRangeActivationCondition(begin = Option(date.atZone(zone).toInstant), timezone = zone),
               description = description.getOrElse(""),
-              tags = tags
+              tags = tags,
+              lastCall = lastCall
             ),
             None
           )
@@ -88,7 +91,8 @@ sealed trait OldFeature {
               condition =
                 ZonedHourPeriod(timezone = zone, hourPeriod = HourPeriod(startTime = startAt, endTime = endAt)),
               description = description.getOrElse(""),
-              tags = tags
+              tags = tags,
+              lastCall = lastCall
             ),
             None
           )
@@ -103,7 +107,8 @@ sealed trait OldFeature {
               project = project,
               condition = UserPercentage(percentage = percentage),
               description = description.getOrElse(""),
-              tags = tags
+              tags = tags,
+              lastCall = lastCall
             ),
             None
           )
@@ -118,7 +123,8 @@ sealed trait OldFeature {
               project = project,
               condition = UserList(users = customers.toSet),
               description = description.getOrElse(""),
-              tags = tags
+              tags = tags,
+              lastCall = lastCall
             ),
             None
           )
@@ -140,7 +146,8 @@ sealed trait OldFeature {
                 functionName = Some("execute"),
                 wasi = true
               ),
-              resultType = BooleanResult
+              resultType = BooleanResult,
+              lastCall = lastCall
             ),
             Some(script)
           )
@@ -165,7 +172,8 @@ sealed trait OldFeature {
                     functionName = Some("execute"),
                     wasi = true
                   ),
-                  resultType = BooleanResult
+                  resultType = BooleanResult,
+                  lastCall = lastCall
                 ),
                 None
               )

--- a/app/fr/maif/izanami/web/FeatureController.scala
+++ b/app/fr/maif/izanami/web/FeatureController.scala
@@ -4,7 +4,14 @@ import fr.maif.izanami.env.Env
 import fr.maif.izanami.errors.{FeatureNotFound, IncorrectKey, IzanamiError, TagDoesNotExists}
 import fr.maif.izanami.models.Feature._
 import fr.maif.izanami.models._
-import fr.maif.izanami.models.features.{ActivationCondition, BooleanResult, FeaturePatch, ProjectFeaturePatch, ResultType}
+import fr.maif.izanami.models.features.{
+  ActivationCondition,
+  BooleanResult,
+  FeaturePatch,
+  ProjectFeaturePatch,
+  ResultType
+}
+import fr.maif.izanami.services.FeatureService
 import fr.maif.izanami.utils.Helpers
 import fr.maif.izanami.utils.syntax.implicits.BetterSyntax
 import fr.maif.izanami.web.FeatureController.queryFeatures
@@ -20,168 +27,185 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 class FeatureController(
-                         val env: Env,
-                         val controllerComponents: ControllerComponents,
-                         val projectAuthAction: ProjectAuthActionFactory,
-                         val authenticatedAction: AuthenticatedAction,
-                         val detailledRightForTenanFactory: DetailledRightForTenantFactory
-                       ) extends BaseController {
+    val env: Env,
+    val controllerComponents: ControllerComponents,
+    val projectAuthAction: ProjectAuthActionFactory,
+    val authenticatedAction: AuthenticatedAction,
+    val detailledRightForTenanFactory: DetailledRightForTenantFactory,
+    featureService: FeatureService
+) extends BaseController {
   implicit val ec: ExecutionContext = env.executionContext
 
   def testFeature(tenant: String, user: String, date: Instant): Action[JsValue] =
-    authenticatedAction.async(parse.json) { implicit request => {
-      Feature.readCompleteFeature(((request.body \ "feature").as[JsObject]).applyOn(json => {
-        val hasName = (json \ "name").asOpt[String].exists(_.nonEmpty)
-        if (!hasName) {
-          json + ("name" -> JsString("test"))
-        } else {
-          json
-        }
-      })) match {
-        case JsError(e) => BadRequest(Json.obj("message" -> "bad body format")).future
-        case JsSuccess(feature, _) => {
-          val featureToEval = feature match {
-            case w: CompleteWasmFeature if w.wasmConfig.source.kind == WasmSourceKind.Local =>
-              w.copy(wasmConfig =
-                w.wasmConfig.copy(source = w.wasmConfig.source.copy(path = s"${tenant}/${w.wasmConfig.source.path}"))
-              )
-            case f => f
-          }
-          Feature
-            .writeFeatureForCheck(featureToEval, RequestContext(tenant = "_test_", user = user, now = date, data = (request.body \ "payload").asOpt[JsObject].getOrElse(Json.obj())), env)
-            .map {
-              case Left(value) => value.toHttpResponse
-              case Right(json) => Ok(json)
+    authenticatedAction.async(parse.json) { implicit request =>
+      {
+        Feature.readCompleteFeature(
+          ((request.body \ "feature")
+            .as[JsObject])
+            .applyOn(json => {
+              val hasName = (json \ "name").asOpt[String].exists(_.nonEmpty)
+              if (!hasName) {
+                json + ("name" -> JsString("test"))
+              } else {
+                json
+              }
+            })
+        ) match {
+          case JsError(e)            => BadRequest(Json.obj("message" -> "bad body format")).future
+          case JsSuccess(feature, _) => {
+            val featureToEval = feature match {
+              case w: CompleteWasmFeature if w.wasmConfig.source.kind == WasmSourceKind.Local =>
+                w.copy(wasmConfig =
+                  w.wasmConfig.copy(source = w.wasmConfig.source.copy(path = s"${tenant}/${w.wasmConfig.source.path}"))
+                )
+              case f                                                                          => f
             }
-        }
+            Feature
+              .writeFeatureForCheck(
+                featureToEval,
+                RequestContext(
+                  tenant = "_test_",
+                  user = user,
+                  now = date,
+                  data = (request.body \ "payload").asOpt[JsObject].getOrElse(Json.obj())
+                ),
+                env
+              )
+              .map {
+                case Left(value) => value.toHttpResponse
+                case Right(json) => Ok(json)
+              }
+          }
 
+        }
       }
-    }
     }
 
   def testExistingFeatureWithoutContext(tenant: String, id: String, user: String, date: Instant): Action[JsValue] =
     testExistingFeature(tenant, FeatureContextPath(Seq()), id, user, date)
 
   def testExistingFeature(
-                           tenant: String,
-                           context: FeatureContextPath,
-                           id: String,
-                           user: String,
-                           date: Instant
-                         ): Action[JsValue] = authenticatedAction.async(parse.json) { implicit request => {
-    lazy val data: JsObject = Option(request.body).flatMap(json => json.asOpt[JsObject]).getOrElse(JsObject.empty)
-    env.datastores.features
-      .findById(
-        tenant,
-        id
-      )
-      .flatMap(eitherFeature => {
-        eitherFeature.fold(
-          err => Future(Results.Status(err.status)(Json.toJson(err))),
-          maybeFeature => {
-            maybeFeature
-              .map(feature =>
-                env.datastores.featureContext
-                  .readStrategyForContext(tenant, context.elements, feature)
-                  .flatMap {
-                    case Some(strategy) => {
-                      strategy
-                        .value(RequestContext(tenant = tenant, user, context = context, now = date, data = data), env)
-                        .map {
-                          case Left(value) => value.toHttpResponse
-                          case Right(active) =>
-                            Ok(
-                              Json.obj(
-                                "active" -> active,
-                                "project" -> feature.project,
-                                "name" -> feature.name
-                              )
-                            )
-                        }
-                    }
-                    case None =>
-                      Feature
-                        .writeFeatureForCheck(
-                          feature,
-                          RequestContext(tenant = tenant, user = user, now = date, context = context, data = data),
-                          env
-                        )
-                        .map {
-                          case Left(error) => error.toHttpResponse
-                          case Right(json) => Ok(json)
-                        }
-                  }
-              )
-              .getOrElse(Future(NotFound(Json.obj("message" -> s"Feature $id does not exist"))))
-          }
+      tenant: String,
+      context: FeatureContextPath,
+      id: String,
+      user: String,
+      date: Instant
+  ): Action[JsValue] = authenticatedAction.async(parse.json) { implicit request =>
+    {
+      lazy val data: JsObject = Option(request.body).flatMap(json => json.asOpt[JsObject]).getOrElse(JsObject.empty)
+      env.datastores.features
+        .findById(
+          tenant,
+          id
         )
-      })
+        .flatMap(eitherFeature => {
+          eitherFeature.fold(
+            err => Future(Results.Status(err.status)(Json.toJson(err))),
+            maybeFeature => {
+              maybeFeature
+                .map(feature =>
+                  env.datastores.featureContext
+                    .readStrategyForContext(tenant, context.elements, feature)
+                    .flatMap {
+                      case Some(strategy) => {
+                        strategy
+                          .value(RequestContext(tenant = tenant, user, context = context, now = date, data = data), env)
+                          .map {
+                            case Left(value)   => value.toHttpResponse
+                            case Right(active) =>
+                              Ok(
+                                Json.obj(
+                                  "active"  -> active,
+                                  "project" -> feature.project,
+                                  "name"    -> feature.name
+                                )
+                              )
+                          }
+                      }
+                      case None           =>
+                        Feature
+                          .writeFeatureForCheck(
+                            feature,
+                            RequestContext(tenant = tenant, user = user, now = date, context = context, data = data),
+                            env
+                          )
+                          .map {
+                            case Left(error) => error.toHttpResponse
+                            case Right(json) => Ok(json)
+                          }
+                    }
+                )
+                .getOrElse(Future(NotFound(Json.obj("message" -> s"Feature $id does not exist"))))
+            }
+          )
+        })
 
-  }
+    }
   }
 
   def checkFeatureForContext(
-                              id: String,
-                              user: String,
-                              context: fr.maif.izanami.web.FeatureContextPath
-                            ): Action[AnyContent] = Action.async { implicit request => {
-    val maybeBody = request.body.asJson.flatMap(jsValue => jsValue.asOpt[JsObject])
-    val basicAuth: Option[(String, String)] = request.headers
-      .get("Authorization")
-      .map(header => header.split("Basic "))
-      .filter(splitted => splitted.length == 2)
-      .map(splitted => splitted(1))
-      .map(header => {
-        Base64.getDecoder.decode(header.getBytes)
-      })
-      .map(bytes => new String(bytes))
-      .map(header => header.split(":"))
-      .filter(arr => arr.length == 2)
-      .map(arr => (arr(0), arr(1)))
-    val customHeaders: Option[(String, String)] = for {
-      clientId <- request.headers.get("Izanami-Client-Id")
-      clientSecret <- request.headers.get("Izanami-Client-Secret")
-    } yield (clientId, clientSecret)
-    val authTuple: Option[(String, String)] = basicAuth.orElse(customHeaders)
+      id: String,
+      user: String,
+      context: fr.maif.izanami.web.FeatureContextPath
+  ): Action[AnyContent] = Action.async { implicit request =>
+    {
+      val maybeBody                               = request.body.asJson.flatMap(jsValue => jsValue.asOpt[JsObject])
+      val basicAuth: Option[(String, String)]     = request.headers
+        .get("Authorization")
+        .map(header => header.split("Basic "))
+        .filter(splitted => splitted.length == 2)
+        .map(splitted => splitted(1))
+        .map(header => {
+          Base64.getDecoder.decode(header.getBytes)
+        })
+        .map(bytes => new String(bytes))
+        .map(header => header.split(":"))
+        .filter(arr => arr.length == 2)
+        .map(arr => (arr(0), arr(1)))
+      val customHeaders: Option[(String, String)] = for {
+        clientId     <- request.headers.get("Izanami-Client-Id")
+        clientSecret <- request.headers.get("Izanami-Client-Secret")
+      } yield (clientId, clientSecret)
+      val authTuple: Option[(String, String)]     = basicAuth.orElse(customHeaders)
 
-    authTuple match {
-      case Some((clientId, clientSecret)) => {
-        val futureTenant = ApiKey.extractTenant(clientId) match {
-          case None => env.datastores.apiKeys.findLegacyKeyTenant(clientId)
-          case s@Some(_) => s.future
+      authTuple match {
+        case Some((clientId, clientSecret)) => {
+          val futureTenant = ApiKey.extractTenant(clientId) match {
+            case None        => env.datastores.apiKeys.findLegacyKeyTenant(clientId)
+            case s @ Some(_) => s.future
+          }
+
+          futureTenant
+            .flatMap {
+              case Some(tenant) =>
+                env.datastores.features
+                  .findByIdForKey(tenant, id, context.elements, clientId, clientSecret)
+                  .map(maybeFeature => maybeFeature.map(feature => (tenant, feature)))
+              case None         => Future.successful(None)
+            }
+            .flatMap {
+              case Some((tenant, feature)) =>
+                Feature
+                  .writeFeatureForCheck(
+                    feature,
+                    RequestContext(
+                      tenant = tenant,
+                      user = user,
+                      context = context,
+                      data = maybeBody.getOrElse(Json.obj())
+                    ),
+                    env = env
+                  )
+                  .map {
+                    case Left(error) => error.toHttpResponse
+                    case Right(json) => Ok(json)
+                  }
+              case None                    => Unauthorized(Json.obj("message" -> "Key does not authorize read for this feature")).future
+            }
         }
-
-        futureTenant
-          .flatMap {
-            case Some(tenant) =>
-              env.datastores.features
-                .findByIdForKey(tenant, id, context.elements, clientId, clientSecret)
-                .map(maybeFeature => maybeFeature.map(feature => (tenant, feature)))
-            case None => Future.successful(None)
-          }
-          .flatMap {
-            case Some((tenant, feature)) =>
-              Feature
-                .writeFeatureForCheck(
-                  feature,
-                  RequestContext(
-                    tenant = tenant,
-                    user = user,
-                    context = context,
-                    data = maybeBody.getOrElse(Json.obj())
-                  ),
-                  env = env
-                )
-                .map {
-                  case Left(error) => error.toHttpResponse
-                  case Right(json) => Ok(json)
-                }
-            case None => Unauthorized(Json.obj("message" -> "Key does not authorize read for this feature")).future
-          }
+        case None                           => Unauthorized(Json.obj("message" -> "Missing or incorrect authorization headers")).future
       }
-      case None => Unauthorized(Json.obj("message" -> "Missing or incorrect authorization headers")).future
     }
-  }
   }
 
   def processInputSeqString(input: Seq[String]): Set[String] = {
@@ -196,14 +220,14 @@ class FeatureController(
   }
 
   def evaluateFeaturesForContext(
-                                  user: String,
-                                  conditions: Boolean,
-                                  date: Option[Instant],
-                                  featureRequest: FeatureRequest
-                                ): Action[AnyContent] = Action.async {
-    implicit request => {
-      val maybeBody = request.body.asJson.flatMap(jsValue => jsValue.asOpt[JsObject])
-      val basicAuth: Option[(String, String)] = request.headers
+      user: String,
+      conditions: Boolean,
+      date: Option[Instant],
+      featureRequest: FeatureRequest
+  ): Action[AnyContent] = Action.async { implicit request =>
+    {
+      val maybeBody                               = request.body.asJson.flatMap(jsValue => jsValue.asOpt[JsObject])
+      val basicAuth: Option[(String, String)]     = request.headers
         .get("Authorization")
         .map(header => header.split("Basic "))
         .filter(splitted => splitted.length == 2)
@@ -216,14 +240,14 @@ class FeatureController(
         .filter(arr => arr.length == 2)
         .map(arr => (arr(0), arr(1)))
       val customHeaders: Option[(String, String)] = for {
-        clientId <- request.headers.get("Izanami-Client-Id")
+        clientId     <- request.headers.get("Izanami-Client-Id")
         clientSecret <- request.headers.get("Izanami-Client-Secret")
       } yield (clientId, clientSecret)
 
       val authTuple: Option[(String, String)] = basicAuth.orElse(customHeaders)
 
       authTuple match {
-        case None => Unauthorized(Json.obj("message" -> "Missing or incorrect authorization headers")).future
+        case None                           => Unauthorized(Json.obj("message" -> "Missing or incorrect authorization headers")).future
         case Some((clientId, clientSecret)) => {
 
           val futureMaybeTenant = ApiKey
@@ -231,8 +255,9 @@ class FeatureController(
             .map(t => Future.successful(Some(t)))
             .getOrElse(env.datastores.apiKeys.findLegacyKeyTenant(clientId))
 
-          futureMaybeTenant.flatMap {
-              case None => Left(IncorrectKey()).future
+          futureMaybeTenant
+            .flatMap {
+              case None         => Left(IncorrectKey()).future
               case Some(tenant) =>
                 val requestContext = RequestContext(
                   tenant = tenant,
@@ -244,7 +269,7 @@ class FeatureController(
                 queryFeatures2(conditions, requestContext, featureRequest, clientId, clientSecret)
             }
             .map {
-              case Left(err) => err.toHttpResponse
+              case Left(err)    => err.toHttpResponse
               case Right(value) => Ok(value)
             }
         }
@@ -253,13 +278,18 @@ class FeatureController(
   }
 
   def testFeaturesForContext(
-                              tenant: String,
-                              user: String,
-                              date: Option[Instant],
-                              featureRequest: FeatureRequest
-                            ): Action[AnyContent] = authenticatedAction.async { implicit request =>
+      tenant: String,
+      user: String,
+      date: Option[Instant],
+      featureRequest: FeatureRequest
+  ): Action[AnyContent] = authenticatedAction.async { implicit request =>
     val futureFeaturesByProject =
-      env.datastores.features.findByRequestV2(tenant, featureRequest, contexts = featureRequest.context, request.user.username)
+      env.datastores.features.findByRequestV2(
+        tenant,
+        featureRequest,
+        contexts = featureRequest.context,
+        request.user.username
+      )
 
     futureFeaturesByProject.flatMap(featuresByProjects => {
       val resultingFeatures = featuresByProjects.values.flatMap(featSeq => featSeq.map(f => f.id)).toSet
@@ -290,7 +320,7 @@ class FeatureController(
                   )
                   .map(either => (feature, either))
                   .map {
-                    case (feature, Left(error)) =>
+                    case (feature, Left(error))   =>
                       feature.id -> Json
                         .obj("error" -> error.message, "name" -> feature.name, "project" -> feature.project)
                     case (feature, Right(active)) =>
@@ -328,10 +358,16 @@ class FeatureController(
                   )
                 ).toFuture
               } else {
-                env.datastores.features.applyPatch(tenant, fs, UserInformation(username = request.user.username, authentication = request.authentication)).map {
-                  case Left(value) => value.toHttpResponse
-                  case Right(_) => NoContent
-                }
+                env.datastores.features
+                  .applyPatch(
+                    tenant,
+                    fs,
+                    UserInformation(username = request.user.username, authentication = request.authentication)
+                  )
+                  .map {
+                    case Left(value) => value.toHttpResponse
+                    case Right(_)    => NoContent
+                  }
               }
             })
         })
@@ -341,10 +377,10 @@ class FeatureController(
   def createFeature(tenant: String, project: String): Action[JsValue] =
     projectAuthAction(tenant, project, RightLevels.Write).async(parse.json) { implicit request =>
       Feature.readCompleteFeature(request.body, project) match {
-        case JsError(e) => BadRequest(Json.obj("message" -> "bad body format")).future
+        case JsError(e)                                                                                => BadRequest(Json.obj("message" -> "bad body format")).future
         case JsSuccess(f: CompleteWasmFeature, _) if f.resultType != BooleanResult && f.wasmConfig.opa =>
           BadRequest(Json.obj("message" -> "OPA feature must have boolean result type")).future
-        case JsSuccess(feature, _) => {
+        case JsSuccess(feature, _)                                                                     => {
           env.datastores.tags
             .readTags(tenant, feature.tags)
             .flatMap {
@@ -352,20 +388,21 @@ class FeatureController(
                 val tagsToCreate = feature.tags.diff(tags.map(t => t.name).toSet)
                 env.datastores.tags.createTags(tagsToCreate.map(name => TagCreationRequest(name = name)).toList, tenant)
               }
-              case tags => Right(tags).toFuture
+              case tags                                  => Right(tags).toFuture
             }
             .flatMap(_ =>
               env.datastores.features
                 .create(tenant, project, feature, request.user)
-                .flatMap { either => {
-                  either match {
-                    case Right(id) =>
-                      env.datastores.features
-                        .findById(tenant, id)
-                        .map(either => either.flatMap(o => o.toRight(FeatureNotFound(id.toString))))
-                    case Left(err) => Future.successful(Left(err))
+                .flatMap { either =>
+                  {
+                    either match {
+                      case Right(id) =>
+                        env.datastores.features
+                          .findById(tenant, id)
+                          .map(either => either.flatMap(o => o.toRight(FeatureNotFound(id.toString))))
+                      case Left(err) => Future.successful(Left(err))
+                    }
                   }
-                }
                 }
                 .map(maybeFeature =>
                   maybeFeature
@@ -373,7 +410,7 @@ class FeatureController(
                       err =>
                         err match {
                           case e: TagDoesNotExists => Results.Status(BAD_REQUEST)(Json.toJson(err))
-                          case e => Results.Status(e.status)(Json.toJson(e))
+                          case e                   => Results.Status(e.status)(Json.toJson(e))
                         },
                       (feat: AbstractFeature) => Created(Json.toJson(feat)(featureWrite))
                     )
@@ -386,10 +423,10 @@ class FeatureController(
   def updateFeature(tenant: String, id: String): Action[JsValue] =
     detailledRightForTenanFactory(tenant).async(parse.json) { implicit request =>
       Feature.readCompleteFeature(request.body) match {
-        case JsError(e) => BadRequest(Json.obj("message" -> "bad body format")).future
+        case JsError(e)                                                                                => BadRequest(Json.obj("message" -> "bad body format")).future
         case JsSuccess(f: CompleteWasmFeature, _) if f.resultType != BooleanResult && f.wasmConfig.opa =>
           BadRequest(Json.obj("message" -> "OPA feature must have boolean result type")).future
-        case JsSuccess(feature, _) => {
+        case JsSuccess(feature, _)                                                                     => {
           env.postgresql.executeInTransaction(
             conn => {
               env.datastores.tags
@@ -400,38 +437,43 @@ class FeatureController(
                     env.datastores.tags
                       .createTags(tagsToCreate.map(name => TagCreationRequest(name = name)).toList, tenant, Some(conn))
                   }
-                  case tags => Right(tags).toFuture
-                }.flatMap {
-                  case Left(err) => Future.successful(err.toHttpResponse)
-                  case Right(value) => env.datastores.features
-                    .findById(tenant, id)
-                    .flatMap {
-                      case Left(err) => err.toHttpResponse.future
-                      case Right(None) => NotFound("").toFuture
-                      case Right(Some(oldFeature)) if !canCreateOrModifyFeature(oldFeature, request.user) =>
-                        Forbidden("Your are not allowed to modify this feature").toFuture
-                      case Right(Some(oldFeature)) => {
-                        env.datastores.features
-                          .update(
-                            tenant = tenant,
-                            id = id,
-                            feature = feature,
-                            user = UserInformation(username = request.user.username, authentication = request.authentication),
-                            conn = Some(conn)
-                          )
-                          .flatMap {
-                            case Right(id) => env.datastores.features.findById(tenant, id, conn = Some(conn))
-                            case Left(err) => Future.successful(Left(err))
-                          }
-                          .map(maybeFeature =>
-                            convertReadResult(
-                              maybeFeature,
-                              callback = feature => Ok(Json.toJson(feature)(featureWrite)),
-                              id = id.toString
+                  case tags                                  => Right(tags).toFuture
+                }
+                .flatMap {
+                  case Left(err)    => Future.successful(err.toHttpResponse)
+                  case Right(value) =>
+                    env.datastores.features
+                      .findById(tenant, id)
+                      .flatMap {
+                        case Left(err)                                                                      => err.toHttpResponse.future
+                        case Right(None)                                                                    => NotFound("").toFuture
+                        case Right(Some(oldFeature)) if !canCreateOrModifyFeature(oldFeature, request.user) =>
+                          Forbidden("Your are not allowed to modify this feature").toFuture
+                        case Right(Some(oldFeature))                                                        => {
+                          env.datastores.features
+                            .update(
+                              tenant = tenant,
+                              id = id,
+                              feature = feature,
+                              user = UserInformation(
+                                username = request.user.username,
+                                authentication = request.authentication
+                              ),
+                              conn = Some(conn)
                             )
-                          )
+                            .flatMap {
+                              case Right(id) => env.datastores.features.findById(tenant, id, conn = Some(conn))
+                              case Left(err) => Future.successful(Left(err))
+                            }
+                            .map(maybeFeature =>
+                              convertReadResult(
+                                maybeFeature,
+                                callback = feature => Ok(Json.toJson(feature)(featureWrite)),
+                                id = id.toString
+                              )
+                            )
+                        }
                       }
-                    }
                 }
             },
             schemas = Set(tenant)
@@ -444,10 +486,10 @@ class FeatureController(
     apiKey.enabled && apiKey.projects.exists(p => p.name == feature.project)
 
   def convertReadResult(
-                         either: Either[IzanamiError, Option[AbstractFeature]],
-                         callback: AbstractFeature => Result,
-                         id: String = ""
-                       ): Result = {
+      either: Either[IzanamiError, Option[AbstractFeature]],
+      callback: AbstractFeature => Result,
+      id: String = ""
+  ): Result = {
     either
       .flatMap(o => o.toRight(FeatureNotFound(id)))
       .fold(
@@ -472,13 +514,17 @@ class FeatureController(
       env.datastores.features
         .findById(tenant, id)
         .flatMap {
-          case Left(err) => err.toHttpResponse.future
-          case Right(None) => NotFound("").toFuture
+          case Left(err)            => err.toHttpResponse.future
+          case Right(None)          => NotFound("").toFuture
           case Right(Some(feature)) => {
 
             if (canCreateOrModifyFeature(feature, request.user)) {
               env.datastores.features
-                .delete(tenant, id, UserInformation(username = request.user.username, authentication = request.authentication))
+                .delete(
+                  tenant,
+                  id,
+                  UserInformation(username = request.user.username, authentication = request.authentication)
+                )
                 .map(maybeFeature =>
                   maybeFeature
                     .map(_ => NoContent)
@@ -492,140 +538,80 @@ class FeatureController(
 
   }
 
-  def queryFeatures2(conditions: Boolean,
-                     requestContext: RequestContext,
-                     featureRequest: FeatureRequest,
-                     clientId: String,
-                     clientSecret: String): Future[Either[IzanamiError, JsValue]] = {
-    val features = retrieveFeatureFromQuery(conditions, featureRequest, clientId, clientSecret)
-    val evaluatedFeatures = features.flatMap {
-      case Left(error) => Left(error).future
-      case Right(f) => evaluateFeatures(f, requestContext, env)
-    }
+  def queryFeatures2(
+      conditions: Boolean,
+      requestContext: RequestContext,
+      featureRequest: FeatureRequest,
+      clientId: String,
+      clientSecret: String
+  ): Future[Either[IzanamiError, JsValue]] = {
+
+    val evaluatedFeatures =
+      featureService.evaluateFeatures(conditions, requestContext, featureRequest, clientId, clientSecret)
     evaluatedFeatures.map {
-      case Left(error) => Left(error)
+      case Left(error)                      => Left(error)
       case Right(evaluatedCompleteFeatures) =>
         val response = formatFeatureResponse(evaluatedCompleteFeatures, conditions)
         registerCalls(requestContext.tenant, clientId, evaluatedCompleteFeatures)
         // TODO handle error
         Right(response)
     }
+
   }
 
-  def retrieveFeatureFromQuery(conditions: Boolean,
-                               featureRequest: FeatureRequest,
-                               clientId: String,
-                               clientSecret: String): Future[Either[IzanamiError, Seq[FeatureStrategies]]] = {
-
-
-    val futureMaybeTenant = ApiKey
-      .extractTenant(clientId)
-      .map(t => Future.successful(Some(t)))
-      .getOrElse(env.datastores.apiKeys.findLegacyKeyTenant(clientId))
-
-    val result = futureMaybeTenant.flatMap {
-      case None => Left(IncorrectKey()).future
-      case Some(tenant) => {
-        if (conditions) {
-          val futureFeaturesByProject =
-            env.datastores.features.doFindByRequestForKey(tenant, featureRequest, clientId, clientSecret, true)
-          futureFeaturesByProject.map {
-            case Left(error) => Left(error)
-            case Right(featuresByProjects) if featuresByProjects.isEmpty => Left(IncorrectKey())
-            case Right(featuresByProjects) => {
-              val strategies = featuresByProjects.toSeq.flatMap {
-                case (_, features) => {
-                  features.map {
-                    case (_, featureAndContexts) => {
-                      // TODO turn featureAndContext into instance of FeatureStrategies
-                      val strategyByCtx = featureAndContexts.map {
-                        case (Some(ctx), feat) => (ctx, feat)
-                        case (None, feat) => ("", feat)
-                      }.toMap
-
-                      FeatureStrategies(strategyByCtx)
-                    }
-                  }
-                }
-              }
-              Right(strategies)
-            }
-          }
-        } else {
-          val futureFeaturesByProject = env.datastores.features.findByRequestForKey(
-            tenant,
-            featureRequest,
-            clientId,
-            clientSecret
-          )
-
-          futureFeaturesByProject.map {
-            case Left(error) => Left(error)
-            case Right(featuresByProjects) if featuresByProjects.isEmpty => Left(IncorrectKey())
-            case Right(featuresByProjects) => {
-              // TODO turn return type of findByRequestForKey to FeatureStrategies so that we don't have to use
-              //  an empty context here
-              val strategies = featuresByProjects.values.flatten.map(v => FeatureStrategies(v)).toSeq
-              Right(strategies)
-            }
-          }
-        }
-      }
-    }
-    result
-  }
-
-  def evaluateFeatures(features: Seq[FeatureStrategies], requestContext: RequestContext, env: Env): Future[Either[IzanamiError, Seq[EvaluatedCompleteFeature]]] = {
-    val evaluatedFeatures = Future.sequence(features.map(f => f.evaluate(requestContext, env)))
-    evaluatedFeatures.map(Helpers.sequence(_))
-  }
-
-  def formatFeatureResponse(evaluatedCompleteFeatures: Seq[EvaluatedCompleteFeature], conditions: Boolean): JsValue = {
-    val fields = evaluatedCompleteFeatures.map(evaluated => {
+  private def formatFeatureResponse(
+      evaluatedCompleteFeatures: Seq[EvaluatedCompleteFeature],
+      conditions: Boolean
+  ): JsValue = {
+    val fields = evaluatedCompleteFeatures
+      .map(evaluated => {
         val active: JsValueWrapper = evaluated.result
-      var baseJson = Json.obj(
-        "name" -> evaluated.baseFeature.name,
-        "active" -> active,
-        "project" -> evaluated.baseFeature.project
-      )
+        var baseJson               = Json.obj(
+          "name"    -> evaluated.baseFeature.name,
+          "active"  -> active,
+          "project" -> evaluated.baseFeature.project
+        )
 
-      if(conditions) {
-        val jsonStrategies = Json
-          .toJson(evaluated.featureStrategies.strategies.map {
-            case (ctx, feature) => {
-              (
-                ctx.replace("_", "/"),
-                writeConditions(feature)
-              )
-            }
-          })
-          .as[JsObject]
-        baseJson = baseJson + ("conditions" -> jsonStrategies)
-      }
+        if (conditions) {
+          val jsonStrategies = Json
+            .toJson(evaluated.featureStrategies.strategies.map {
+              case (ctx, feature) => {
+                (
+                  ctx.replace("_", "/"),
+                  writeConditions(feature)
+                )
+              }
+            })
+            .as[JsObject]
+          baseJson = baseJson + ("conditions" -> jsonStrategies)
+        }
         (evaluated.baseFeature.id, baseJson)
       })
       .toMap
     Json.toJson(fields)
   }
 
-  def registerCalls(tenant: String, key: String, evaluatedCompleteFeatures: Seq[EvaluatedCompleteFeature]): Future[Either[IzanamiError, Unit]] = {
+  private def registerCalls(
+      tenant: String,
+      key: String,
+      evaluatedCompleteFeatures: Seq[EvaluatedCompleteFeature]
+  ): Future[Either[IzanamiError, Unit]] = {
     val valuesByFeature = evaluatedCompleteFeatures.map(evaluated => (evaluated.baseFeature.id, evaluated.result)).toMap
     env.datastores.featureCalls.registerCall(tenant, key, valuesByFeature)
   }
 
-
   def writeConditions(f: CompleteFeature): JsObject = {
     val resultType: JsValueWrapper = Json.toJson(f.resultType)(ResultType.resultTypeWrites)
-    val baseJson = Json.obj(
-      "enabled" -> f.enabled,
+    val baseJson                   = Json.obj(
+      "enabled"    -> f.enabled,
       "resultType" -> resultType
     )
     f match {
       case w: CompleteWasmFeature => baseJson + ("wasmConfig" -> Json.obj("name" -> w.wasmConfig.name))
-      case f => {
+      case f                      => {
         val conditions = f match {
           case s: SingleConditionFeature => s.toModernFeature.resultDescriptor.conditions
-          case f: Feature => f.resultDescriptor.conditions
+          case f: Feature                => f.resultDescriptor.conditions
         }
         baseJson + ("conditions" -> Json.toJson(conditions)(Writes.seq(ActivationCondition.activationConditionWrite)))
       }
@@ -636,43 +622,43 @@ class FeatureController(
 object FeatureController {
 
   def queryFeatures(
-                     user: String,
-                     conditions: Boolean,
-                     date: Option[Instant],
-                     featureRequest: FeatureRequest,
-                     clientId: String,
-                     clientSecret: String,
-                     maybeBody: Option[JsObject],
-                     env: Env
-                   ): Future[Either[IzanamiError, JsValue]] = {
+      user: String,
+      conditions: Boolean,
+      date: Option[Instant],
+      featureRequest: FeatureRequest,
+      clientId: String,
+      clientSecret: String,
+      maybeBody: Option[JsObject],
+      env: Env
+  ): Future[Either[IzanamiError, JsValue]] = {
     implicit val executionContext: ExecutionContext = env.executionContext
-    val futureMaybeTenant = ApiKey
+    val futureMaybeTenant                           = ApiKey
       .extractTenant(clientId)
       .map(t => Future.successful(Some(t)))
       .getOrElse(env.datastores.apiKeys.findLegacyKeyTenant(clientId))
 
     futureMaybeTenant.flatMap {
-      case None => Left(IncorrectKey()).future
+      case None         => Left(IncorrectKey()).future
       case Some(tenant) => {
         if (conditions) {
           val futureFeaturesByProject =
             env.datastores.features.doFindByRequestForKey(tenant, featureRequest, clientId, clientSecret, true)
           futureFeaturesByProject.transformWith {
-            case Failure(exception) => Left(fr.maif.izanami.errors.InternalServerError()).future
-            case Success(Left(error)) => Left(error).future
+            case Failure(exception)                                               => Left(fr.maif.izanami.errors.InternalServerError()).future
+            case Success(Left(error))                                             => Left(error).future
             case Success(Right(featuresByProjects)) if featuresByProjects.isEmpty => Left(IncorrectKey()).future
-            case Success(Right(featuresByProjects)) => {
+            case Success(Right(featuresByProjects))                               => {
               val strategiesByFeatureId = featuresByProjects.toSeq.flatMap {
                 case (projectId, features) => {
                   val futures: Seq[Future[Either[(String, IzanamiError), (String, JsObject)]]] = features.toSeq.map {
                     case (featureId, featureAndContexts) => {
                       val strategyByCtx = featureAndContexts.map {
                         case (Some(ctx), feat) => (ctx, feat)
-                        case (None, feat) => ("", feat)
+                        case (None, feat)      => ("", feat)
                       }.toMap
 
                       // TODO fatorize this separator
-                      val ctxStr = featureRequest.context.mkString("_")
+                      val ctxStr        = featureRequest.context.mkString("_")
                       val strategyToUse = if (ctxStr.isBlank) {
                         strategyByCtx("")
                       } else {
@@ -681,7 +667,7 @@ object FeatureController {
                           .toSeq
                           .sortWith {
                             case ((c1, _), (c2, _)) if c1.length < c2.length => false
-                            case _ => true
+                            case _                                           => true
                           }
                           .headOption
                           .map(_._2)
@@ -694,18 +680,18 @@ object FeatureController {
                             (
                               ctx.replace("_", "/"),
                               (feature match {
-                                case w: CompleteWasmFeature =>
+                                case w: CompleteWasmFeature     =>
                                   Feature.featureWrite
                                     .writes(w)
                                     .as[
-                                    JsObject
-                                  ] - "wasmConfig" - "tags" - "name" - "description" - "id" - "project" ++ Json
+                                      JsObject
+                                    ] - "wasmConfig" - "tags" - "name" - "description" - "id" - "project" ++ Json
                                     .obj("wasmConfig" -> Json.obj("name" -> w.wasmConfig.name))
                                 case lf: SingleConditionFeature =>
                                   Feature.featureWrite
                                     .writes(lf.toModernFeature)
                                     .as[JsObject] - "tags" - "name" - "description" - "id" - "project"
-                                case f => Feature.featureWrite.writes(f).as[JsObject]
+                                case f                          => Feature.featureWrite.writes(f).as[JsObject]
                               }) - "metadata" - "tags" - "name" - "description" - "id" - "project"
                             )
                           }
@@ -723,7 +709,7 @@ object FeatureController {
                         ),
                         env = env
                       ).map {
-                        case Left(err) => Left((featureId, err))
+                        case Left(err)          => Left((featureId, err))
                         case Right(jsonFeature) => {
                           val entry = jsonFeature ++ Json.obj("conditions" -> jsonStrategies)
                           Right((featureId, entry))
@@ -755,10 +741,10 @@ object FeatureController {
           )
 
           futureFeaturesByProject.transformWith {
-            case Failure(exception) => Left(fr.maif.izanami.errors.InternalServerError()).future
-            case Success(Left(error)) => Left(error).future
+            case Failure(exception)                                               => Left(fr.maif.izanami.errors.InternalServerError()).future
+            case Success(Left(error))                                             => Left(error).future
             case Success(Right(featuresByProjects)) if featuresByProjects.isEmpty => Left(IncorrectKey()).future
-            case Success(Right(featuresByProjects)) => {
+            case Success(Right(featuresByProjects))                               => {
               Future
                 .sequence(
                   featuresByProjects.values.flatten
@@ -777,7 +763,7 @@ object FeatureController {
                         )
                         .map(either => (feature.id, either))
                         .map {
-                          case (id, Left(error)) => id -> Json.obj("error" -> error.message)
+                          case (id, Left(error))   => id -> Json.obj("error" -> error.message)
                           case (id, Right(active)) => id -> active
                         }
                     )

--- a/app/fr/maif/izanami/web/FeatureController.scala
+++ b/app/fr/maif/izanami/web/FeatureController.scala
@@ -4,17 +4,9 @@ import fr.maif.izanami.env.Env
 import fr.maif.izanami.errors.{FeatureNotFound, IncorrectKey, IzanamiError, TagDoesNotExists}
 import fr.maif.izanami.models.Feature._
 import fr.maif.izanami.models._
-import fr.maif.izanami.models.features.{
-  ActivationCondition,
-  BooleanResult,
-  FeaturePatch,
-  ProjectFeaturePatch,
-  ResultType
-}
+import fr.maif.izanami.models.features._
 import fr.maif.izanami.services.FeatureService
-import fr.maif.izanami.utils.Helpers
 import fr.maif.izanami.utils.syntax.implicits.BetterSyntax
-import fr.maif.izanami.web.FeatureController.queryFeatures
 import io.otoroshi.wasm4s.scaladsl.WasmSourceKind
 import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.Json.JsValueWrapper
@@ -24,7 +16,6 @@ import play.api.mvc._
 import java.time.Instant
 import java.util.Base64
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
 
 class FeatureController(
     val env: Env,
@@ -266,7 +257,7 @@ class FeatureController(
                   context = FeatureContextPath(featureRequest.context),
                   data = maybeBody.getOrElse(Json.obj())
                 )
-                queryFeatures2(conditions, requestContext, featureRequest, clientId, clientSecret)
+                queryFeatures(conditions, requestContext, featureRequest, clientId, clientSecret)
             }
             .map {
               case Left(err)    => err.toHttpResponse
@@ -538,7 +529,7 @@ class FeatureController(
 
   }
 
-  def queryFeatures2(
+  private def queryFeatures(
       conditions: Boolean,
       requestContext: RequestContext,
       featureRequest: FeatureRequest,
@@ -614,165 +605,6 @@ class FeatureController(
           case f: Feature                => f.resultDescriptor.conditions
         }
         baseJson + ("conditions" -> Json.toJson(conditions)(Writes.seq(ActivationCondition.activationConditionWrite)))
-      }
-    }
-  }
-}
-
-object FeatureController {
-
-  def queryFeatures(
-      user: String,
-      conditions: Boolean,
-      date: Option[Instant],
-      featureRequest: FeatureRequest,
-      clientId: String,
-      clientSecret: String,
-      maybeBody: Option[JsObject],
-      env: Env
-  ): Future[Either[IzanamiError, JsValue]] = {
-    implicit val executionContext: ExecutionContext = env.executionContext
-    val futureMaybeTenant                           = ApiKey
-      .extractTenant(clientId)
-      .map(t => Future.successful(Some(t)))
-      .getOrElse(env.datastores.apiKeys.findLegacyKeyTenant(clientId))
-
-    futureMaybeTenant.flatMap {
-      case None         => Left(IncorrectKey()).future
-      case Some(tenant) => {
-        if (conditions) {
-          val futureFeaturesByProject =
-            env.datastores.features.doFindByRequestForKey(tenant, featureRequest, clientId, clientSecret, true)
-          futureFeaturesByProject.transformWith {
-            case Failure(exception)                                               => Left(fr.maif.izanami.errors.InternalServerError()).future
-            case Success(Left(error))                                             => Left(error).future
-            case Success(Right(featuresByProjects)) if featuresByProjects.isEmpty => Left(IncorrectKey()).future
-            case Success(Right(featuresByProjects))                               => {
-              val strategiesByFeatureId = featuresByProjects.toSeq.flatMap {
-                case (projectId, features) => {
-                  val futures: Seq[Future[Either[(String, IzanamiError), (String, JsObject)]]] = features.toSeq.map {
-                    case (featureId, featureAndContexts) => {
-                      val strategyByCtx = featureAndContexts.map {
-                        case (Some(ctx), feat) => (ctx, feat)
-                        case (None, feat)      => ("", feat)
-                      }.toMap
-
-                      // TODO fatorize this separator
-                      val ctxStr        = featureRequest.context.mkString("_")
-                      val strategyToUse = if (ctxStr.isBlank) {
-                        strategyByCtx("")
-                      } else {
-                        strategyByCtx
-                          .filter { case (ctx, f) => ctxStr.startsWith(ctx) }
-                          .toSeq
-                          .sortWith {
-                            case ((c1, _), (c2, _)) if c1.length < c2.length => false
-                            case _                                           => true
-                          }
-                          .headOption
-                          .map(_._2)
-                          .getOrElse(strategyByCtx(""))
-                      }
-
-                      val jsonStrategies = Json
-                        .toJson(strategyByCtx.map {
-                          case (ctx, feature) => {
-                            (
-                              ctx.replace("_", "/"),
-                              (feature match {
-                                case w: CompleteWasmFeature     =>
-                                  Feature.featureWrite
-                                    .writes(w)
-                                    .as[
-                                      JsObject
-                                    ] - "wasmConfig" - "tags" - "name" - "description" - "id" - "project" ++ Json
-                                    .obj("wasmConfig" -> Json.obj("name" -> w.wasmConfig.name))
-                                case lf: SingleConditionFeature =>
-                                  Feature.featureWrite
-                                    .writes(lf.toModernFeature)
-                                    .as[JsObject] - "tags" - "name" - "description" - "id" - "project"
-                                case f                          => Feature.featureWrite.writes(f).as[JsObject]
-                              }) - "metadata" - "tags" - "name" - "description" - "id" - "project"
-                            )
-                          }
-                        })
-                        .as[JsObject]
-
-                      writeFeatureForCheck(
-                        strategyToUse,
-                        RequestContext(
-                          tenant = tenant,
-                          user = user,
-                          now = date.getOrElse(Instant.now()),
-                          context = FeatureContextPath(featureRequest.context),
-                          data = maybeBody.getOrElse(Json.obj())
-                        ),
-                        env = env
-                      ).map {
-                        case Left(err)          => Left((featureId, err))
-                        case Right(jsonFeature) => {
-                          val entry = jsonFeature ++ Json.obj("conditions" -> jsonStrategies)
-                          Right((featureId, entry))
-                        }
-                      }
-                    }
-                  }
-                  futures
-                }
-              }
-
-              Future
-                .sequence(strategiesByFeatureId)
-                .map(s => {
-                  s.map {
-                    case Left((featureId, error)) => (featureId, Json.obj("error" -> error.message))
-                    case Right((featureId, json)) => (featureId, json)
-                  }.toMap
-                })
-                .map(map => Right(Json.toJson(map)))
-            }
-          }
-        } else {
-          val futureFeaturesByProject = env.datastores.features.findByRequestForKey(
-            tenant,
-            featureRequest,
-            clientId,
-            clientSecret
-          )
-
-          futureFeaturesByProject.transformWith {
-            case Failure(exception)                                               => Left(fr.maif.izanami.errors.InternalServerError()).future
-            case Success(Left(error))                                             => Left(error).future
-            case Success(Right(featuresByProjects)) if featuresByProjects.isEmpty => Left(IncorrectKey()).future
-            case Success(Right(featuresByProjects))                               => {
-              Future
-                .sequence(
-                  featuresByProjects.values.flatten
-                    .map(feature =>
-                      Feature
-                        .writeFeatureForCheck(
-                          feature,
-                          context = RequestContext(
-                            tenant = tenant,
-                            user = user,
-                            now = date.getOrElse(Instant.now()),
-                            context = FeatureContextPath(featureRequest.context),
-                            data = maybeBody.getOrElse(Json.obj())
-                          ),
-                          env = env
-                        )
-                        .map(either => (feature.id, either))
-                        .map {
-                          case (id, Left(error))   => id -> Json.obj("error" -> error.message)
-                          case (id, Right(active)) => id -> active
-                        }
-                    )
-                )
-                .map(_.toMap)
-                .map(map => Right(Json.toJson(map)))
-            }
-          }
-        }
       }
     }
   }

--- a/app/fr/maif/izanami/web/FeatureController.scala
+++ b/app/fr/maif/izanami/web/FeatureController.scala
@@ -633,41 +633,6 @@ class FeatureController(
   }
 }
 
-case class FeatureStrategies(strategies: Map[String, CompleteFeature]) {
-
-  def evaluate(requestContext: RequestContext, env: Env): Future[Either[IzanamiError, EvaluatedCompleteFeature]] = {
-    val context = requestContext.contextAsString
-    val strategyToUse = if (context.isBlank) {
-      strategies("")
-    } else {
-      strategies
-        .filter { case (ctx, f) => context.startsWith(ctx) }
-        .toSeq
-        .sortWith {
-          case ((c1, _), (c2, _)) if c1.length < c2.length => false
-          case _ => true
-        }
-        .headOption
-        .map(_._2)
-        .getOrElse(strategies(""))
-    }
-    strategyToUse.value(requestContext, env).map(either => either.map(v => EvaluatedCompleteFeature(this, v)))(env.executionContext)
-  }
-
-}
-
-case class EvaluatedCompleteFeature(featureStrategies: FeatureStrategies, result: JsValue) {
-  def baseFeature: CompleteFeature = {
-    featureStrategies.strategies("")
-  }
-}
-
-case object FeatureStrategies {
-  def apply(f: CompleteFeature): FeatureStrategies = {
-    FeatureStrategies(Map("" -> f))
-  }
-}
-
 object FeatureController {
 
   def queryFeatures(

--- a/app/fr/maif/izanami/web/StaleFeatureController.scala
+++ b/app/fr/maif/izanami/web/StaleFeatureController.scala
@@ -1,0 +1,31 @@
+package fr.maif.izanami.web
+
+import fr.maif.izanami.env.Env
+import fr.maif.izanami.services.StaleFeatureService
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+
+import java.time.Duration
+import scala.concurrent.ExecutionContext
+
+class StaleFeatureController(
+    env: Env,
+    staleFeatureService: StaleFeatureService,
+    val controllerComponents: ControllerComponents
+) extends BaseController {
+
+  implicit val ec: ExecutionContext = env.executionContext
+
+  private val defaultDelay =
+    env.configuration.getOptional[Duration]("izanami.stale-feature.delay").getOrElse(Duration.ofDays(30L))
+
+  def staleFeatures(tenant: String, delay: Option[Duration]): Action[AnyContent] = Action.async { _ =>
+    staleFeatureService
+      .reportStaleFeatures(tenant, delay.getOrElse(defaultDelay))
+      .map({
+        case Left(error)     => InternalServerError(Json.obj("error" -> error.message))
+        case Right(features) => Ok(Json.obj("features" -> features))
+      })
+  }
+
+}

--- a/conf/routes
+++ b/conf/routes
@@ -97,6 +97,7 @@ GET           /api/admin/tenants/:tenant/local-scripts/:script                  
 PUT           /api/admin/tenants/:tenant/local-scripts/:script                                     fr.maif.izanami.web.PluginController.updateScript(tenant: String, script: String)
 DELETE        /api/admin/local-scripts/_cache                                                      fr.maif.izanami.web.PluginController.clearWasmCache()
 DELETE        /api/admin/tenants/:tenant/local-scripts/:script                                     fr.maif.izanami.web.PluginController.deleteScript(tenant: String, script: String)
+GET           /api/admin/tenants/:tenant/stale-features                                            fr.maif.izanami.web.StaleFeatureController.staleFeatures(tenant: String, for: Option[java.time.Duration])
 
 POST          /api/admin/tenants/:tenant/_import                                                   fr.maif.izanami.web.ImportController.importData(version: Int, tenant: String, conflict: String, timezone: Option[String], deduceProject: Boolean ?= false, create: Option[Boolean], project: Option[String], projectPartSize: Option[Int], inlineScript: Option[Boolean])
 GET           /api/admin/tenants/:tenant/_import/:id                                               fr.maif.izanami.web.ImportController.readImportStatus(tenant: String, id: String)


### PR DESCRIPTION
Implements #923

Changes:

- [ ] Show features stale globally (across contexts)

    - [x] Store feature calls to a new table `feature_calls`
    - [x] Add configuration flag for the delay after which declaring a feature as stale
    - [x] Return `lastCall` field when listing project features
    - [ ] Return `stale` boolean field when listing project features (not necessarily add it to the `AbstractFeature` objects, it may be computed on-the-fly)
    - [ ] Show indicator in UI for project features with `stale` field at `true`; Tooltip shall contain `lastCall`

- [ ] Show feature stale by context
   - [ ] Return `lastCall` by context when listing context overloads
   - [ ] Update UI

- [ ] Periodically Raise alerts  about stale features (mail?)
   - [ ] Allow configuration of alerting rules about stale features: Whitelist
   - [ ] Periodically scan `feature_calls` against these alerting rules
   - [ ] Define alerting method (mail?)

- [ ] Housekeeping: Clear old feature calls

Open issues:

 - Table schema: Currently a line by event. Is it performant enough? Does it scale (it we have a lot of calls)? Move to an array?
 - SSE: Should we record when a new event is sent? It may be a lot (see previous bullet). Currently it's not performed.