### PR TITLE
Feat/cli open id connect

### DIFF
--- a/app/fr/maif/izanami/IzaConfig.scala
+++ b/app/fr/maif/izanami/IzaConfig.scala
@@ -123,7 +123,8 @@ case class AppConf(
     search: Search,
     feature: Feature,
     housekeeping: Housekeeping,
-    cluster: Cluster
+    cluster: Cluster,
+    cliAuth: CliAuth
 )
 
 object AppConf {
@@ -269,6 +270,7 @@ case class CallRecords(
     callRetentionTimeInHours: Long
 )
 case class Housekeeping(startDelayInSeconds: Long, intervalInSeconds: Long)
+case class CliAuth(storage: String = "in-memory")
 case class RoleRights(
     admin: Boolean = false,
     tenants: Map[String, TenantRoleRights] = Map(),

--- a/app/fr/maif/izanami/datastores/CliAuthDatastore.scala
+++ b/app/fr/maif/izanami/datastores/CliAuthDatastore.scala
@@ -1,0 +1,221 @@
+package fr.maif.izanami.datastores
+
+import fr.maif.izanami.env.Env
+import fr.maif.izanami.errors._
+import fr.maif.izanami.models.PendingCliAuth
+import fr.maif.izanami.utils.Datastore
+
+import java.security.SecureRandom
+import java.util.Base64
+import scala.concurrent.Future
+
+/**
+ * Storage interface for CLI OIDC authentication state.
+ *
+ * This trait defines the contract for storing and retrieving CLI authentication state
+ * during the browser-based OIDC flow. Implementations must handle:
+ * - Pending authentication entries (waiting for user to complete browser auth)
+ * - Completed authentication entries (token ready for CLI pickup)
+ * - Rate limiting to prevent brute force attacks
+ * - Cleanup of expired entries
+ *
+ * == Available Implementations ==
+ *
+ * - [[InMemoryCliAuthStorage]]: Default, suitable for single-instance deployments
+ * - [[PostgresCliAuthStorage]]: For clustered deployments behind a load balancer
+ *
+ * @see [[CliAuthDatastore]] for the factory that selects the appropriate implementation
+ */
+trait CliAuthStorage {
+  /**
+   * Creates a pending CLI authentication entry.
+   *
+   * @param state The cryptographically secure state parameter
+   * @param codeVerifier Optional PKCE code verifier for secure token exchange
+   * @return Either an error or the created pending auth entry
+   */
+  def createPendingAuth(state: String, codeVerifier: Option[String] = None): Future[Either[IzanamiError, PendingCliAuth]]
+
+  /**
+   * Retrieves and removes a pending auth entry.
+   * Used when the OIDC callback completes to get the code verifier.
+   *
+   * @param state The state parameter to look up
+   * @return The pending auth if found and not expired, None otherwise
+   */
+  def consumePendingAuth(state: String): Future[Option[PendingCliAuth]]
+
+  /**
+   * Checks if a state corresponds to a pending CLI authentication.
+   *
+   * @param state The state parameter to check
+   * @return True if a pending auth exists for this state
+   */
+  def isPendingCliAuth(state: String): Future[Boolean]
+
+  /**
+   * Stores a completed authentication token for CLI retrieval.
+   *
+   * @param state The state parameter identifying the auth flow
+   * @param token The authentication token to store
+   * @return Either an error or success
+   */
+  def storeCompletedAuth(state: String, token: String): Future[Either[IzanamiError, Unit]]
+
+  /**
+   * Attempts to claim the token for a given state.
+   * Includes rate limiting to prevent brute force attacks.
+   *
+   * @param state The state parameter to look up
+   * @return Either an error, None (still pending), or Some(token) on success
+   */
+  def claimToken(state: String): Future[Either[IzanamiError, Option[String]]]
+
+  /**
+   * Called when the storage is started. Used for initializing cleanup tasks.
+   */
+  def onStart(): Future[Unit]
+
+  /**
+   * Called when the storage is stopped. Used for cleanup.
+   */
+  def onStop(): Future[Unit]
+}
+
+/**
+ * Datastore for CLI OIDC authentication state management.
+ *
+ * This datastore manages the state-based token exchange flow that allows CLI tools
+ * to authenticate users via browser-based OIDC without needing a local callback server.
+ *
+ * == Authentication Flow ==
+ *
+ * 1. CLI generates a cryptographically secure state (32 bytes, base64url encoded)
+ * 2. CLI opens browser to `/api/admin/cli-login?state={state}`
+ * 3. Backend stores pending auth and redirects to OIDC provider with `state=cli:{state}`
+ * 4. User authenticates in browser
+ * 5. OIDC callback detects CLI flow via `cli:` prefix, exchanges code for token
+ * 6. Backend stores completed auth with token for CLI pickup
+ * 7. CLI polls `/api/admin/cli-token?state={state}` to retrieve token
+ *
+ * == Why the `cli:` Prefix in State Parameter ==
+ *
+ * The OIDC callback endpoint (`/api/admin/openid-connect-callback`) receives the same
+ * parameters for both browser and CLI authentication flows. The backend must distinguish
+ * between them to know whether to:
+ * - '''Browser flow''': Create a session cookie and redirect to the dashboard
+ * - '''CLI flow''': Store the token for polling pickup and show a "close window" message
+ *
+ * The `cli:` prefix approach was chosen over alternatives:
+ *
+ * | Approach | Pros | Cons |
+ * |----------|------|------|
+ * | '''Prefix in state''' (`cli:xxx`) | Simple, no extra params, state survives redirect | Slightly unconventional |
+ * | Separate callback URL | Clean separation | Requires OIDC provider to allow multiple redirect URIs |
+ * | Query param (`?flow=cli`) | Explicit | May not survive OIDC redirect (provider might strip unknown params) |
+ * | Store flow type in DB | Clean state param | Extra DB lookup before knowing flow type |
+ *
+ * === Is It Safe? ===
+ *
+ * Yes. The OAuth 2.0 spec (RFC 6749) defines the state parameter as:
+ * ''"An opaque value used by the client to maintain state between the request and callback"''
+ *
+ * The OIDC provider passes it through unchanged without interpreting its contents.
+ * We simply parse the prefix on return to determine the flow type.
+ *
+ * === Alternatives in Other Tools ===
+ *
+ * - '''GitHub CLI''' (`gh`): Uses a local HTTP server on localhost as callback
+ * - '''AWS CLI''': Uses device authorization flow (different OAuth grant type)
+ * - '''Google Cloud CLI''': Similar local server approach
+ *
+ * The prefix approach avoids requiring users to have a free local port, making it
+ * simpler for CLI tools that may run in restricted environments.
+ *
+ * == Storage Backend Selection ==
+ *
+ * The storage backend is selected based on configuration:
+ * - `app.cli-auth.storage = "in-memory"` (default): Uses [[InMemoryCliAuthStorage]]
+ * - `app.cli-auth.storage = "database"`: Uses [[PostgresCliAuthStorage]]
+ *
+ * For clustered deployments, use database storage to ensure state is shared across instances.
+ *
+ * @see [[fr.maif.izanami.models.PendingCliAuth]]
+ * @see [[fr.maif.izanami.models.CompletedCliAuth]]
+ */
+class CliAuthDatastore(val env: Env) extends Datastore {
+
+  private val secureRandom: SecureRandom = new SecureRandom()
+  private val STATE_SIZE_BYTES: Int      = 32 // 256 bits of entropy
+
+  /**
+   * The underlying storage implementation, selected based on configuration.
+   */
+  private val storage: CliAuthStorage = env.typedConfiguration.cliAuth.storage.toLowerCase match {
+    case "database" | "db" =>
+      env.logger.info("CLI auth storage: database")
+      new PostgresCliAuthStorage(env)
+    case _ =>
+      env.logger.info("CLI auth storage: in-memory")
+      new InMemoryCliAuthStorage(env)
+  }
+
+  override def onStart(): Future[Unit] = storage.onStart()
+
+  override def onStop(): Future[Unit] = storage.onStop()
+
+  /**
+   * Generates a cryptographically secure state parameter.
+   *
+   * @return A base64url-encoded string with 256 bits of entropy
+   */
+  def generateState(): String = {
+    val bytes = new Array[Byte](STATE_SIZE_BYTES)
+    secureRandom.nextBytes(bytes)
+    Base64.getUrlEncoder.withoutPadding().encodeToString(bytes)
+  }
+
+  /**
+   * Validates state parameter format (base64url, correct length).
+   *
+   * @param state The state parameter to validate
+   * @return True if the state matches the expected format
+   */
+  def isValidState(state: String): Boolean = {
+    state != null &&
+    state.length >= 40 &&
+    state.length <= 50 &&
+    state.matches("^[A-Za-z0-9_-]+$")
+  }
+
+  /**
+   * Creates a pending CLI authentication entry.
+   */
+  def createPendingAuth(state: String, codeVerifier: Option[String] = None): Future[Either[IzanamiError, PendingCliAuth]] =
+    storage.createPendingAuth(state, codeVerifier)
+
+  /**
+   * Retrieves and removes a pending auth entry, returning the code verifier if present.
+   */
+  def consumePendingAuth(state: String): Future[Option[PendingCliAuth]] =
+    storage.consumePendingAuth(state)
+
+  /**
+   * Checks if a state corresponds to a CLI authentication flow.
+   */
+  def isPendingCliAuth(state: String): Future[Boolean] =
+    storage.isPendingCliAuth(state)
+
+  /**
+   * Stores a completed authentication token for CLI retrieval.
+   */
+  def storeCompletedAuth(state: String, token: String): Future[Either[IzanamiError, Unit]] =
+    storage.storeCompletedAuth(state, token)
+
+  /**
+   * Retrieves and deletes the token for a given state.
+   * Includes rate limiting to prevent brute force attacks.
+   */
+  def claimToken(state: String): Future[Either[IzanamiError, Option[String]]] =
+    storage.claimToken(state)
+}

--- a/app/fr/maif/izanami/datastores/InMemoryCliAuthStorage.scala
+++ b/app/fr/maif/izanami/datastores/InMemoryCliAuthStorage.scala
@@ -1,0 +1,147 @@
+package fr.maif.izanami.datastores
+
+import org.apache.pekko.actor.Cancellable
+import fr.maif.izanami.env.Env
+import fr.maif.izanami.errors._
+import fr.maif.izanami.models.{CompletedCliAuth, PendingCliAuth}
+
+import play.api.Logger
+
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+/**
+ * In-memory implementation of CLI OIDC authentication state storage.
+ *
+ * This implementation is suitable for single-instance deployments where all requests
+ * are handled by the same server. It uses ConcurrentHashMap for thread-safe state management.
+ *
+ * == Limitations ==
+ *
+ * - State is lost on server restart
+ * - Does not work in clustered environments with multiple Izanami instances
+ *   behind a load balancer (CLI login might hit instance A, callback hits instance B)
+ *
+ * For clustered deployments, use [[PostgresCliAuthStorage]] instead by setting
+ * `IZANAMI_CLI_AUTH_STORAGE=postgresql`.
+ *
+ * @see [[CliAuthStorage]] for the storage interface
+ * @see [[PostgresCliAuthStorage]] for the PostgreSQL-backed implementation
+ */
+class InMemoryCliAuthStorage(env: Env) extends CliAuthStorage {
+
+  private implicit val ec: scala.concurrent.ExecutionContext = env.executionContext
+  private val logger = Logger("izanami.cli-auth")
+
+  private val pendingAuths   = new ConcurrentHashMap[String, PendingCliAuth]()
+  private val completedAuths = new ConcurrentHashMap[String, CompletedCliAuth]()
+
+  // Rate limiting: track poll attempts per state
+  private val pollAttempts = new ConcurrentHashMap[String, (Int, Instant)]()
+
+  private var cleanupTask: Cancellable = Cancellable.alreadyCancelled
+
+  // Configuration constants
+  private val PENDING_AUTH_TTL_SECONDS: Long    = 300  // 5 minutes
+  private val COMPLETED_AUTH_TTL_SECONDS: Long  = 120  // 2 minutes
+  private val MAX_POLL_ATTEMPTS_PER_MINUTE: Int = 60   // Rate limit
+
+  override def onStart(): Future[Unit] = {
+    // Schedule cleanup task every 30 seconds
+    cleanupTask = env.actorSystem.scheduler.scheduleAtFixedRate(
+      30.seconds,
+      30.seconds
+    )(() => cleanupExpiredEntries())
+    Future.successful(())
+  }
+
+  override def onStop(): Future[Unit] = {
+    cleanupTask.cancel()
+    pendingAuths.clear()
+    completedAuths.clear()
+    pollAttempts.clear()
+    Future.successful(())
+  }
+
+  override def createPendingAuth(state: String, codeVerifier: Option[String] = None): Future[Either[IzanamiError, PendingCliAuth]] = {
+    val now     = Instant.now()
+    val pending = PendingCliAuth(
+      state = state,
+      createdAt = now,
+      expiresAt = now.plusSeconds(PENDING_AUTH_TTL_SECONDS),
+      codeVerifier = codeVerifier
+    )
+    pendingAuths.put(state, pending)
+    logger.debug(s"[InMemory] Created pending auth - state: $state, pendingAuths size: ${pendingAuths.size()}")
+    Future.successful(Right(pending))
+  }
+
+  override def consumePendingAuth(state: String): Future[Option[PendingCliAuth]] = {
+    logger.debug(s"[InMemory] consumePendingAuth - state: $state, pendingAuths contains key: ${pendingAuths.containsKey(state)}")
+    val pending      = Option(pendingAuths.remove(state))
+    val validPending = pending.filter(p => Instant.now().isBefore(p.expiresAt))
+    logger.debug(s"[InMemory] consumePendingAuth - found: ${pending.isDefined}, valid: ${validPending.isDefined}")
+    Future.successful(validPending)
+  }
+
+  override def isPendingCliAuth(state: String): Future[Boolean] = {
+    Future.successful(pendingAuths.containsKey(state))
+  }
+
+  override def storeCompletedAuth(state: String, token: String): Future[Either[IzanamiError, Unit]] = {
+    val now       = Instant.now()
+    val completed = CompletedCliAuth(
+      state = state,
+      token = token,
+      createdAt = now,
+      expiresAt = now.plusSeconds(COMPLETED_AUTH_TTL_SECONDS)
+    )
+    completedAuths.put(state, completed)
+    logger.debug(s"[InMemory] Stored completed auth - state: $state, completedAuths size: ${completedAuths.size()}")
+    Future.successful(Right(()))
+  }
+
+  override def claimToken(state: String): Future[Either[IzanamiError, Option[String]]] = {
+    logger.debug(s"[InMemory] claimToken - state: $state, completedAuths contains: ${completedAuths.containsKey(state)}, pendingAuths contains: ${pendingAuths.containsKey(state)}")
+    // Rate limiting check
+    val now                     = Instant.now()
+    val (attempts, windowStart) = Option(pollAttempts.get(state)).getOrElse((0, now))
+
+    if (now.isAfter(windowStart.plusSeconds(60))) {
+      // Reset window
+      pollAttempts.put(state, (1, now))
+    } else if (attempts >= MAX_POLL_ATTEMPTS_PER_MINUTE) {
+      logger.debug(s"[InMemory] claimToken - rate limited for state: $state")
+      return Future.successful(Left(CliAuthRateLimited()))
+    } else {
+      pollAttempts.put(state, (attempts + 1, windowStart))
+    }
+
+    Option(completedAuths.remove(state)) match {
+      case Some(completed) if Instant.now().isBefore(completed.expiresAt) =>
+        pollAttempts.remove(state) // Clean up rate limit tracking
+        logger.debug(s"[InMemory] claimToken - returning token for state: $state")
+        Future.successful(Right(Some(completed.token)))
+      case Some(_) =>
+        logger.debug(s"[InMemory] claimToken - expired for state: $state")
+        Future.successful(Left(CliAuthStateExpired(state)))
+      case None if pendingAuths.containsKey(state) =>
+        // Still pending - token not ready yet
+        logger.debug(s"[InMemory] claimToken - still pending for state: $state")
+        Future.successful(Right(None))
+      case None =>
+        logger.debug(s"[InMemory] claimToken - not found for state: $state")
+        Future.successful(Left(CliAuthStateNotFound(state)))
+    }
+  }
+
+  private def cleanupExpiredEntries(): Unit = {
+    val now = Instant.now()
+
+    pendingAuths.entrySet().removeIf(e => now.isAfter(e.getValue.expiresAt))
+    completedAuths.entrySet().removeIf(e => now.isAfter(e.getValue.expiresAt))
+    pollAttempts.entrySet().removeIf(e => now.isAfter(e.getValue._2.plusSeconds(120)))
+  }
+}

--- a/app/fr/maif/izanami/datastores/PostgresCliAuthStorage.scala
+++ b/app/fr/maif/izanami/datastores/PostgresCliAuthStorage.scala
@@ -1,0 +1,212 @@
+package fr.maif.izanami.datastores
+
+import org.apache.pekko.actor.Cancellable
+import fr.maif.izanami.env.Env
+import fr.maif.izanami.env.pgimplicits.EnhancedRow
+import fr.maif.izanami.errors._
+import fr.maif.izanami.models.{CompletedCliAuth, PendingCliAuth}
+
+import java.time.{Instant, OffsetDateTime, ZoneOffset}
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+/**
+ * PostgreSQL-backed implementation of CLI OIDC authentication state storage.
+ *
+ * This implementation stores CLI authentication state in PostgreSQL, making it suitable
+ * for clustered deployments where multiple Izanami instances run behind a load balancer.
+ *
+ * == When to Use ==
+ *
+ * Use this storage when:
+ * - Running multiple Izanami instances in a cluster
+ * - State persistence across restarts is required
+ * - CLI login, OIDC callback, and token polling may hit different instances
+ *
+ * Configure by setting `IZANAMI_CLI_AUTH_STORAGE=postgresql`.
+ *
+ * == Security Features ==
+ *
+ * - Atomic rate limiting using PostgreSQL UPDATE with conditional logic
+ * - Single-use tokens: DELETE on successful claim
+ * - Automatic cleanup of expired entries via scheduled task
+ *
+ * @see [[CliAuthStorage]] for the storage interface
+ * @see [[InMemoryCliAuthStorage]] for the in-memory implementation
+ */
+class PostgresCliAuthStorage(env: Env) extends CliAuthStorage {
+
+  private implicit val ec: scala.concurrent.ExecutionContext = env.executionContext
+
+  private var cleanupTask: Cancellable = Cancellable.alreadyCancelled
+
+  // Configuration constants
+  private val PENDING_AUTH_TTL_SECONDS: Long    = 300  // 5 minutes
+  private val COMPLETED_AUTH_TTL_SECONDS: Long  = 120  // 2 minutes
+  private val MAX_POLL_ATTEMPTS_PER_MINUTE: Int = 60   // Rate limit
+
+  override def onStart(): Future[Unit] = {
+    // Schedule cleanup task every 30 seconds
+    cleanupTask = env.actorSystem.scheduler.scheduleAtFixedRate(
+      30.seconds,
+      30.seconds
+    )(() => cleanupExpiredEntries())
+    Future.successful(())
+  }
+
+  override def onStop(): Future[Unit] = {
+    cleanupTask.cancel()
+    Future.successful(())
+  }
+
+  override def createPendingAuth(state: String, codeVerifier: Option[String] = None): Future[Either[IzanamiError, PendingCliAuth]] = {
+    val now       = OffsetDateTime.now(ZoneOffset.UTC)
+    val expiresAt = now.plusSeconds(PENDING_AUTH_TTL_SECONDS)
+
+    env.postgresql.queryOne(
+      """INSERT INTO izanami.cli_auth (state, status, code_verifier, created_at, expires_at)
+         VALUES ($1, 'pending', $2, $3, $4)
+         ON CONFLICT (state) DO UPDATE SET
+           status = 'pending',
+           code_verifier = EXCLUDED.code_verifier,
+           created_at = EXCLUDED.created_at,
+           expires_at = EXCLUDED.expires_at
+         RETURNING state, created_at, expires_at, code_verifier""".stripMargin,
+      List(state, codeVerifier.orNull, now, expiresAt)
+    ) { row =>
+      for {
+        st        <- row.optString("state")
+        createdAt <- row.optOffsetDatetime("created_at")
+        expiresAt <- row.optOffsetDatetime("expires_at")
+      } yield PendingCliAuth(
+        state = st,
+        createdAt = createdAt.toInstant,
+        expiresAt = expiresAt.toInstant,
+        codeVerifier = row.optString("code_verifier")
+      )
+    }.map {
+      case Some(pending) => Right(pending)
+      case None          => Left(InternalServerError("Failed to create pending CLI auth"))
+    }
+  }
+
+  override def consumePendingAuth(state: String): Future[Option[PendingCliAuth]] = {
+    env.postgresql.queryOne(
+      """DELETE FROM izanami.cli_auth
+         WHERE state = $1 AND status = 'pending'::izanami.CLI_AUTH_STATUS AND expires_at > now()
+         RETURNING state, created_at, expires_at, code_verifier""".stripMargin,
+      List(state)
+    ) { row =>
+      for {
+        st        <- row.optString("state")
+        createdAt <- row.optOffsetDatetime("created_at")
+        expiresAt <- row.optOffsetDatetime("expires_at")
+      } yield PendingCliAuth(
+        state = st,
+        createdAt = createdAt.toInstant,
+        expiresAt = expiresAt.toInstant,
+        codeVerifier = row.optString("code_verifier")
+      )
+    }
+  }
+
+  override def isPendingCliAuth(state: String): Future[Boolean] = {
+    env.postgresql.queryOne(
+      """SELECT 1 FROM izanami.cli_auth
+         WHERE state = $1 AND status = 'pending'::izanami.CLI_AUTH_STATUS AND expires_at > now()""".stripMargin,
+      List(state)
+    ) { _ => Some(true) }.map(_.getOrElse(false))
+  }
+
+  override def storeCompletedAuth(state: String, token: String): Future[Either[IzanamiError, Unit]] = {
+    val now       = OffsetDateTime.now(ZoneOffset.UTC)
+    val expiresAt = now.plusSeconds(COMPLETED_AUTH_TTL_SECONDS)
+
+    env.postgresql.queryOne(
+      """INSERT INTO izanami.cli_auth (state, status, token, created_at, expires_at)
+         VALUES ($1, 'completed', $2, $3, $4)
+         ON CONFLICT (state) DO UPDATE SET
+           status = 'completed',
+           token = EXCLUDED.token,
+           created_at = EXCLUDED.created_at,
+           expires_at = EXCLUDED.expires_at
+         RETURNING state""".stripMargin,
+      List(state, token, now, expiresAt)
+    ) { _ => Some(()) }.map {
+      case Some(_) => Right(())
+      case None    => Left(InternalServerError("Failed to store completed CLI auth"))
+    }
+  }
+
+  override def claimToken(state: String): Future[Either[IzanamiError, Option[String]]] = {
+    // First, check and update rate limiting atomically
+    env.postgresql.queryOne(
+      """UPDATE izanami.cli_auth
+         SET poll_count = CASE
+               WHEN poll_window_start IS NULL OR poll_window_start < now() - interval '1 minute'
+               THEN 1
+               ELSE poll_count + 1
+             END,
+             poll_window_start = CASE
+               WHEN poll_window_start IS NULL OR poll_window_start < now() - interval '1 minute'
+               THEN now()
+               ELSE poll_window_start
+             END
+         WHERE state = $1
+         RETURNING status, token, expires_at, poll_count""".stripMargin,
+      List(state)
+    ) { row =>
+      val pollCount = row.optInt("poll_count").getOrElse(0)
+      val status    = row.optString("status")
+      val token     = row.optString("token")
+      val expiresAt = row.optOffsetDatetime("expires_at")
+
+      Some((pollCount, status, token, expiresAt))
+    }.flatMap {
+      case Some((pollCount, status, token, expiresAt)) =>
+        if (pollCount > MAX_POLL_ATTEMPTS_PER_MINUTE) {
+          Future.successful(Left(CliAuthRateLimited()))
+        } else {
+          status match {
+            case Some("completed") =>
+              val now = Instant.now()
+              expiresAt match {
+                case Some(exp) if exp.toInstant.isAfter(now) =>
+                  // Token is valid - delete it and return
+                  deleteAndReturnToken(state, token)
+                case _ =>
+                  // Token has expired
+                  Future.successful(Left(CliAuthStateExpired(state)))
+              }
+            case Some("pending") =>
+              // Still pending - token not ready yet
+              Future.successful(Right(None))
+            case _ =>
+              Future.successful(Left(CliAuthStateNotFound(state)))
+          }
+        }
+      case None =>
+        // State not found at all
+        Future.successful(Left(CliAuthStateNotFound(state)))
+    }
+  }
+
+  private def deleteAndReturnToken(state: String, maybeToken: Option[String]): Future[Either[IzanamiError, Option[String]]] = {
+    env.postgresql.queryOne(
+      """DELETE FROM izanami.cli_auth WHERE state = $1 RETURNING token""".stripMargin,
+      List(state)
+    ) { row =>
+      row.optString("token")
+    }.map {
+      case Some(token) => Right(Some(token))
+      case None        => Right(maybeToken) // Fallback to previously read token if delete returned nothing
+    }
+  }
+
+  private def cleanupExpiredEntries(): Unit = {
+    env.postgresql.queryOne(
+      """DELETE FROM izanami.cli_auth WHERE expires_at < now() RETURNING state""".stripMargin,
+      List()
+    ) { _ => Some(()) }
+  }
+}

--- a/app/fr/maif/izanami/env/env.scala
+++ b/app/fr/maif/izanami/env/env.scala
@@ -42,12 +42,14 @@ class Datastores(env: Env) {
   val personnalAccessToken: PersonnalAccessTokenDatastore =
     new PersonnalAccessTokenDatastore(env)
   val events: EventDatastore = new EventDatastore(env)
+  val cliAuth: CliAuthDatastore = new CliAuthDatastore(env)
 
   def onStart(): Future[Unit] = {
     for {
       _ <- users.onStart()
       _ <- events.onStart()
       _ <- featureCalls.onStart()
+      _ <- cliAuth.onStart()
     } yield ()
   }
 
@@ -56,6 +58,7 @@ class Datastores(env: Env) {
       _ <- users.onStop()
       _ <- events.onStop()
       _ <- featureCalls.onStop()
+      _ <- cliAuth.onStop()
     } yield ()
   }
 }

--- a/app/fr/maif/izanami/errors/Errors.scala
+++ b/app/fr/maif/izanami/errors/Errors.scala
@@ -465,6 +465,36 @@ case class ErrorAggregator(errors: Seq[IzanamiError])
       status = errors.map(_.status).minOption.getOrElse(INTERNAL_SERVER_ERROR)
     ) {}
 
+/**
+ * CLI Authentication Errors
+ *
+ * These errors are used by the CLI OIDC authentication flow, which allows CLI tools
+ * to authenticate users via browser-based OIDC without requiring a local callback server.
+ *
+ * The flow uses a state-based token exchange:
+ * 1. CLI generates a secure state and opens browser to /api/admin/cli-login?state=xxx
+ * 2. Backend stores pending auth and redirects to OIDC provider with state=cli:xxx
+ * 3. User authenticates in browser
+ * 4. OIDC callback detects CLI flow, stores token for pickup
+ * 5. CLI polls /api/admin/cli-token?state=xxx to retrieve token
+ */
+
+/** Returned when polling with a state that was never registered or has already expired */
+case class CliAuthStateNotFound(state: String)
+    extends IzanamiError(message = s"CLI authentication state not found or expired", status = NOT_FOUND)
+
+/** Returned when the token was generated but expired before being claimed (2 min TTL) */
+case class CliAuthStateExpired(state: String)
+    extends IzanamiError(message = s"CLI authentication state has expired", status = 410) // GONE
+
+/** Returned when polling too frequently (more than 60 requests per minute per state) */
+case class CliAuthRateLimited()
+    extends IzanamiError(message = "Too many requests, please slow down", status = 429) // TOO_MANY_REQUESTS
+
+/** Returned when the state parameter doesn't match the expected format (base64url, 40-50 chars) */
+case class CliAuthInvalidState()
+    extends IzanamiError(message = "Invalid state parameter format", status = BAD_REQUEST)
+
 object ErrorAggregator {
   def fromEitherSeq(
       eithers: Seq[Either[IzanamiError, Any]]

--- a/app/fr/maif/izanami/models/CliAuthentication.scala
+++ b/app/fr/maif/izanami/models/CliAuthentication.scala
@@ -1,0 +1,33 @@
+package fr.maif.izanami.models
+
+import java.time.Instant
+
+/**
+ * Represents a pending CLI authentication request waiting for OIDC completion.
+ *
+ * @param state        Cryptographically secure random string (32+ bytes, base64url encoded)
+ * @param createdAt    Timestamp when the request was initiated
+ * @param expiresAt    Timestamp when this pending auth expires (default: 5 minutes from creation)
+ * @param codeVerifier Optional PKCE code verifier if PKCE is enabled
+ */
+case class PendingCliAuth(
+    state: String,
+    createdAt: Instant,
+    expiresAt: Instant,
+    codeVerifier: Option[String] = None
+)
+
+/**
+ * Represents a completed CLI authentication with token ready for pickup.
+ *
+ * @param state     The state parameter used to correlate the request
+ * @param token     The JWT token to be returned to the CLI
+ * @param createdAt When the token was stored
+ * @param expiresAt When this stored token expires (default: 2 minutes from creation)
+ */
+case class CompletedCliAuth(
+    state: String,
+    token: String,
+    createdAt: Instant,
+    expiresAt: Instant
+)

--- a/app/fr/maif/izanami/web/LoginController.scala
+++ b/app/fr/maif/izanami/web/LoginController.scala
@@ -43,6 +43,30 @@ class LoginController(
   implicit val ec: ExecutionContext = env.executionContext
   private val logger = Logger("izanami.login")
 
+  /**
+   * Initiates browser-based OIDC authentication flow.
+   *
+   * == Why State Parameter is Required (CSRF Protection) ==
+   *
+   * The `state` parameter is essential for preventing Cross-Site Request Forgery (CSRF) attacks
+   * on the OAuth callback. Without it, an attacker could:
+   * 1. Initiate an OAuth flow with their own account
+   * 2. Trick a victim into completing the callback
+   * 3. Link the attacker's identity to the victim's session
+   *
+   * == Why PKCE Code Verifier is Not Sufficient ==
+   *
+   * While PKCE (code_verifier/code_challenge) provides some incidental CSRF protection
+   * because the verifier is stored in the session, it is NOT a replacement for state:
+   *
+   * 1. '''Timing''': State is validated before processing; PKCE fails during token exchange
+   * 2. '''Purpose''': PKCE protects against authorization code interception, not CSRF
+   * 3. '''Standards''': OAuth 2.0 Security BCP explicitly states PKCE doesn't replace state
+   *
+   * @see [[https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.7 OAuth 2.0 Security Best Current Practice - CSRF Protection]]
+   * @see [[https://datatracker.ietf.org/doc/html/rfc6749#section-10.12 RFC 6749 - Cross-Site Request Forgery]]
+   * @see [[https://danielfett.de/2020/05/16/pkce-vs-nonce-equivalent-or-not/ PKCE vs State - Security Analysis]]
+   */
   def openIdConnect: Action[AnyContent] = Action.async { implicit request =>
     env.datastores.configuration
       .readFullConfiguration()
@@ -66,18 +90,25 @@ class LoginController(
               (if (!hasOpenIdInScope) oAuth2Configuration.scopes + " openid"
                else oAuth2Configuration.scopes).replace(" ", "%20")
 
+            // Generate state for CSRF protection - required even when PKCE is enabled.
+            // See method documentation for why code_verifier alone is insufficient.
+            val state = generateBrowserState()
+
             if (oAuth2Configuration.pkce.exists(_.enabled)) {
               val (codeVerifier, codeChallenge, codeChallengeMethod) =
                 generatePKCECodes(oAuth2Configuration.pkce.get.algorithm.some)
 
               Redirect(
-                s"${oAuth2Configuration.authorizeUrl}?scope=$actualScope&client_id=${oAuth2Configuration.clientId}&response_type=code&redirect_uri=${oAuth2Configuration.callbackUrl}&code_challenge=$codeChallenge&code_challenge_method=$codeChallengeMethod"
+                s"${oAuth2Configuration.authorizeUrl}?scope=$actualScope&client_id=${oAuth2Configuration.clientId}&response_type=code&redirect_uri=${oAuth2Configuration.callbackUrl}&state=$state&code_challenge=$codeChallenge&code_challenge_method=$codeChallengeMethod"
               ).addingToSession(
-                "code_verifier" -> codeVerifier
+                "code_verifier" -> codeVerifier,
+                "oauth_state" -> state
               )
             } else {
               Redirect(
-                s"${oAuth2Configuration.authorizeUrl}?scope=$actualScope&client_id=${oAuth2Configuration.clientId}&response_type=code&redirect_uri=${oAuth2Configuration.callbackUrl}"
+                s"${oAuth2Configuration.authorizeUrl}?scope=$actualScope&client_id=${oAuth2Configuration.clientId}&response_type=code&redirect_uri=${oAuth2Configuration.callbackUrl}&state=$state"
+              ).addingToSession(
+                "oauth_state" -> state
               )
             }
           }
@@ -113,7 +144,65 @@ class LoginController(
     }
   }
 
+  private def generateBrowserState(): String = {
+    val bytes = new Array[Byte](32)
+    val secureRandom = new SecureRandom()
+    secureRandom.nextBytes(bytes)
+    Base64.getUrlEncoder.withoutPadding().encodeToString(bytes)
+  }
+
+  /**
+   * Handles the OIDC authorization code callback.
+   *
+   * Supports two flows distinguished by the `state` parameter:
+   * - '''Browser flow''': State from callback must match the one stored in session.
+   * - '''CLI flow''': State is prefixed with "cli:" and validated via the pending auth store.
+   *
+   * The state is URL-decoded before processing since OIDC providers may encode special characters.
+   *
+   * @see [[CliAuthDatastore]] for the prefix design decision
+   */
   def openIdCodeReturn: Action[AnyContent] = Action.async { implicit request =>
+    val maybeRawState = request.body.asJson.flatMap(json => (json \ "state").asOpt[String])
+    val maybeState    = maybeRawState.map(s => java.net.URLDecoder.decode(s, "UTF-8"))
+    val isCliFlow     = maybeState.exists(_.startsWith("cli:"))
+    val actualState   = maybeState.map(s => if (s.startsWith("cli:")) s.drop(4) else s)
+
+    val sessionState      = request.session.get("oauth_state")
+    val browserStateValid = isCliFlow || (maybeState.isDefined && sessionState == maybeState)
+
+    if (!isCliFlow && !browserStateValid) {
+      logger.warn(
+        s"OIDC callback state mismatch - possible CSRF attempt. Session: ${sessionState
+            .getOrElse("none")}, callback: ${maybeState.getOrElse("none")}"
+      )
+      Future.successful(
+        BadRequest(Json.obj("message" -> "Invalid state parameter - possible CSRF attack"))
+      )
+    } else {
+      val cliPendingAuthFuture: Future[Option[fr.maif.izanami.models.PendingCliAuth]] =
+        if (isCliFlow && actualState.isDefined)
+          env.datastores.cliAuth.consumePendingAuth(actualState.get)
+        else Future.successful(None)
+
+      cliPendingAuthFuture.flatMap { maybeCliPendingAuth =>
+        if (isCliFlow && maybeCliPendingAuth.isEmpty) {
+          logger.error("CLI authentication state not found or expired")
+          Future.successful(
+            BadRequest(Json.obj("message" -> "CLI authentication state not found or expired"))
+          )
+        } else {
+          processOidcCallback(isCliFlow, actualState, maybeCliPendingAuth)
+        }
+      }
+    }
+  }
+
+  private def processOidcCallback(
+      isCliFlow: Boolean,
+      actualState: Option[String],
+      maybeCliPendingAuth: Option[fr.maif.izanami.models.PendingCliAuth]
+  )(implicit request: Request[AnyContent]): Future[Result] = {
     {
       for (
         code <- request.body.asJson
@@ -178,7 +267,9 @@ class LoginController(
             }
 
             if (oauth2Configuration.pkce.exists(_.enabled)) {
-              val maybeCodeVerifier = request.session.get(s"code_verifier")
+              val maybeCodeVerifier =
+                if (isCliFlow) maybeCliPendingAuth.flatMap(_.codeVerifier)
+                else request.session.get(s"code_verifier")
               if (maybeCodeVerifier.isEmpty) {
                 logger.error(
                   "PKCE flow is required but no code_verifier was found"
@@ -357,7 +448,7 @@ class LoginController(
                       }
                       case Left(err) => Future(Left(err))
                     }
-                    .map(maybeId => {
+                    .flatMap(maybeId => {
                       maybeId
                         .map((id, maybeRightCompliance) => {
                           (
@@ -366,36 +457,13 @@ class LoginController(
                           )
                         })
                         .fold(
-                          err => {
-                            err.toHttpResponse
-                          },
+                          err => Future.successful(err.toHttpResponse),
                           (token, maybeRightCompliance) => {
-                            if (maybeRightCompliance.exists(!_.isEmpty)) {
-                              Ok(
-                                Json.obj(
-                                  "rightUpdates" -> Json.toJson(maybeRightCompliance)(Writes.optionWithNull(MaxRightComplianceResult.writes))
-                                )
-                              )
-                                .withCookies(
-                                  Cookie(
-                                    name = "token",
-                                    value = token,
-                                    httpOnly = false,
-                                    sameSite = Some(SameSite.Strict)
-                                  )
-                                )
+                            if (isCliFlow && actualState.isDefined) {
+                              handleCliOidcCompletion(actualState.get, token)
                             } else {
-                              NoContent
-                                .withCookies(
-                                  Cookie(
-                                    name = "token",
-                                    value = token,
-                                    httpOnly = false,
-                                    sameSite = Some(SameSite.Strict)
-                                  )
-                                )
+                              handleBrowserOidcCompletion(token, maybeRightCompliance)
                             }
-
                           }
                         )
                     })
@@ -404,7 +472,134 @@ class LoginController(
           }
         }
     }.flatten
-    // .getOrElse(Future(InternalServerError(Json.obj("message" -> "Failed to read token claims"))))
+  }
+
+  private def handleCliOidcCompletion(state: String, token: String): Future[Result] = {
+    env.datastores.cliAuth.storeCompletedAuth(state, token).map {
+      case Right(_) =>
+        Ok(
+          Json.obj(
+            "cliAuth" -> true,
+            "message" -> "Authentication successful. You can close this window and return to your terminal."
+          )
+        )
+      case Left(err) =>
+        err.toHttpResponse
+    }
+  }
+
+  private def handleBrowserOidcCompletion(
+      token: String,
+      maybeRightCompliance: Option[MaxRightComplianceResult]
+  ): Future[Result] = {
+    val cookie = Cookie(
+      name = "token",
+      value = token,
+      httpOnly = false,
+      sameSite = Some(SameSite.Strict)
+    )
+    val response =
+      if (maybeRightCompliance.exists(!_.isEmpty)) {
+        Ok(
+          Json.obj(
+            "rightUpdates" -> Json.toJson(maybeRightCompliance)(
+              Writes.optionWithNull(MaxRightComplianceResult.writes)
+            )
+          )
+        )
+      } else {
+        NoContent
+      }
+    Future.successful(response.withCookies(cookie))
+  }
+
+  /**
+   * Initiates CLI OIDC authentication flow.
+   *
+   * The CLI generates a cryptographically secure state parameter and opens the browser
+   * to this endpoint. The backend stores the state and redirects to the OIDC provider
+   * with the state prefixed by `cli:` so [[openIdCodeReturn]] can distinguish CLI from
+   * browser flows.
+   */
+  def cliOpenIdConnect(state: String): Action[AnyContent] = Action.async { implicit request =>
+    if (!env.datastores.cliAuth.isValidState(state)) {
+      Future.successful(BadRequest(Json.obj("message" -> "Invalid state parameter format")))
+    } else {
+      env.datastores.configuration
+        .readFullConfiguration()
+        .value
+        .map(e => e.toOption.flatMap(_.oidcConfiguration))
+        .flatMap {
+          case None => Future.successful(MissingOIDCConfigurationError().toHttpResponse)
+          case Some(oauth2Config) if !oauth2Config.enabled =>
+            Future.successful(BadRequest(Json.obj("message" -> "OIDC is not enabled")))
+          case Some(oauth2Config) =>
+            val hasOpenIdInScope =
+              oauth2Config.scopes.split(" ").exists(_.equalsIgnoreCase("openid"))
+            val actualScope =
+              (if (!hasOpenIdInScope) oauth2Config.scopes + " openid"
+               else oauth2Config.scopes).replace(" ", "%20")
+
+            val (codeVerifier, pkceParams) =
+              if (oauth2Config.pkce.exists(_.enabled)) {
+                val (verifier, challenge, method) =
+                  generatePKCECodes(oauth2Config.pkce.get.algorithm.some)
+                (Some(verifier), s"&code_challenge=$challenge&code_challenge_method=$method")
+              } else {
+                (None, "")
+              }
+
+            env.datastores.cliAuth.createPendingAuth(state, codeVerifier).map {
+              case Right(_) =>
+                val cliState = s"cli:$state"
+                val redirectUrl = s"${oauth2Config.authorizeUrl}?scope=$actualScope" +
+                  s"&client_id=${oauth2Config.clientId}" +
+                  s"&response_type=code" +
+                  s"&redirect_uri=${oauth2Config.callbackUrl}" +
+                  s"&state=$cliState" +
+                  pkceParams
+                Redirect(redirectUrl)
+              case Left(err) =>
+                err.toHttpResponse
+            }
+        }
+    }
+  }
+
+  /**
+   * CLI polls this endpoint to retrieve the authentication token.
+   *
+   * Responses:
+   * - 200 OK with token: Authentication complete, token returned
+   * - 202 Accepted: Authentication in progress, continue polling
+   * - 400 Bad Request: Invalid state format
+   * - 429 Too Many Requests: Rate limited
+   */
+  def cliTokenPoll(state: String): Action[AnyContent] = Action.async { implicit request =>
+    if (!env.datastores.cliAuth.isValidState(state)) {
+      Future.successful(BadRequest(Json.obj("message" -> "Invalid state parameter format")))
+    } else {
+      env.datastores.cliAuth.claimToken(state).map {
+        case Right(Some(token)) =>
+          Ok(Json.obj("token" -> token))
+        case Right(None) =>
+          Accepted(
+            Json.obj(
+              "status" -> "pending",
+              "message" -> "Authentication in progress, please continue polling"
+            )
+          )
+        case Left(_: fr.maif.izanami.errors.CliAuthRateLimited) =>
+          TooManyRequests(
+            Json.obj(
+              "message" -> "Too many requests, please slow down",
+              "retryAfter" -> 5
+            )
+          ).withHeaders("Retry-After" -> "5")
+        case Left(err) =>
+          err.toHttpResponse
+      }
+    }
   }
 
   private def extractRoles(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -178,6 +178,13 @@ app {
     interval-in-seconds = 300
     interval-in-seconds = ${?IZANAMI_HOUSEKEEPING_INTERVAL_IN_SECONDS}
   }
+  cli-auth {
+    # Storage backend for CLI OIDC authentication state.
+    # "in-memory" (default): Fast, suitable for single-instance deployments.
+    # "database": Required for clustered deployments behind a load balancer.
+    storage = "in-memory"
+    storage = ${?IZANAMI_CLI_AUTH_STORAGE}
+  }
 }
 
 # Copyright (C) Lightbend Inc. <https://www.lightbend.com>

--- a/conf/routes
+++ b/conf/routes
@@ -88,6 +88,10 @@ POST          /api/admin/logout                                                 
 GET           /api/admin/openid-connect                                                            fr.maif.izanami.web.LoginController.openIdConnect()
 POST          /api/admin/openid-connect-callback                                                   fr.maif.izanami.web.LoginController.openIdCodeReturn()
 POST          /api/admin/openid-connect/configuration                                              fr.maif.izanami.web.LoginController.fetchOpenIdConnectConfiguration()
+# CLI OIDC authentication - allows CLI tools to authenticate via browser without local callback server
+# Flow: CLI opens browser to cli-login -> user authenticates -> CLI polls cli-token for JWT
+GET           /api/admin/cli-login                                                                 fr.maif.izanami.web.LoginController.cliOpenIdConnect(state: String)
+GET           /api/admin/cli-token                                                                 fr.maif.izanami.web.LoginController.cliTokenPoll(state: String)
 
 PUT           /api/admin/configuration                                                             fr.maif.izanami.web.ConfigurationController.updateConfiguration()
 GET           /api/admin/configuration                                                             fr.maif.izanami.web.ConfigurationController.readConfiguration()

--- a/conf/sql/globals/V22__create_cli_auth_table.sql
+++ b/conf/sql/globals/V22__create_cli_auth_table.sql
@@ -1,0 +1,21 @@
+-- CLI Authentication state storage for clustered deployments
+-- Stores pending and completed CLI OIDC authentication states
+--
+-- This table is used when cli-auth.storage = "postgresql" is configured.
+-- For single-instance deployments, the default in-memory storage is recommended.
+
+CREATE TYPE CLI_AUTH_STATUS AS ENUM ('pending', 'completed');
+
+CREATE TABLE cli_auth (
+    state TEXT PRIMARY KEY,
+    status CLI_AUTH_STATUS NOT NULL DEFAULT 'pending',
+    code_verifier TEXT,
+    token TEXT,
+    poll_count INTEGER NOT NULL DEFAULT 0,
+    poll_window_start TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX idx_cli_auth_expires ON cli_auth(expires_at);
+CREATE INDEX idx_cli_auth_status ON cli_auth(status);

--- a/izanami-frontend/src/pages/login.tsx
+++ b/izanami-frontend/src/pages/login.tsx
@@ -7,18 +7,37 @@ import { TUser } from "../utils/types";
 import { Loader } from "../components/Loader";
 
 export function Login(props: any) {
-  const code = new URLSearchParams(props.location.search).get("code");
+  const searchParams = new URLSearchParams(props.location.search);
+  const code = searchParams.get("code");
+  const state = searchParams.get("state");
   if (code) {
-    return <TokenWaitScreen code={code} />;
+    return <TokenWaitScreen code={code} state={state} />;
   } else {
     return <LoginForm {...props} />;
   }
 }
 
-function TokenWaitScreen({ code }: { code: string }) {
+/**
+ * Handles the OIDC callback after user authenticates with the identity provider.
+ *
+ * This component exchanges the authorization code for tokens. It supports two flows:
+ *
+ * 1. **Standard browser flow**: User is redirected to the dashboard after successful auth.
+ *
+ * 2. **CLI flow**: When the state parameter starts with "cli:", the backend stores the token
+ *    for CLI pickup instead of creating a session. The response includes `{ cliAuth: true }`
+ *    and this component shows a "close this window" message so the user knows to return
+ *    to their terminal where the CLI is polling for the token.
+ *
+ * @param code - The authorization code from the OIDC provider
+ * @param state - Optional state parameter; if prefixed with "cli:" indicates CLI auth flow
+ */
+function TokenWaitScreen({ code, state }: { code: string; state: string | null }) {
   const fetching = React.useRef<boolean>(false);
   const [error, setError] = React.useState("");
   const navigate = useNavigate();
+  const [cliAuthSuccess, setCliAuthSuccess] = React.useState(false);
+
   React.useEffect(() => {
     if (!fetching.current) {
       fetching.current = true;
@@ -28,7 +47,7 @@ function TokenWaitScreen({ code }: { code: string }) {
         headers: {
           "content-type": "application/json",
         },
-        body: JSON.stringify({ code }),
+        body: JSON.stringify({ code, state }),
       }).then((response) => {
         if (response.status >= 400) {
           setError("Failed to retrieve token from code");
@@ -36,17 +55,36 @@ function TokenWaitScreen({ code }: { code: string }) {
           response
             .json()
             .then((payload) => {
-              navigate("/", {
-                state: { message: payload.rightUpdates },
-              });
+              if (payload?.cliAuth) {
+                // CLI flow: show success message, user should return to terminal
+                setCliAuthSuccess(true);
+              } else {
+                navigate("/", {
+                  state: { message: payload?.rightUpdates },
+                });
+              }
             })
             .catch(() => {
+              // No JSON body (NoContent response) - standard browser flow
               window.location.href = "/";
             });
         }
       });
     }
   }, []);
+
+  if (cliAuthSuccess) {
+    return (
+      <div className="d-flex flex-column justify-content-center align-items-center" style={{ minHeight: "50vh" }}>
+        <div className="text-center p-4" style={{ maxWidth: "400px" }}>
+          <i className="fa fa-check-circle text-success" style={{ fontSize: "64px", marginBottom: "20px" }}></i>
+          <h2>Authentication Successful</h2>
+          <p className="text-secondary">You have been authenticated with Izanami.</p>
+          <p className="text-secondary">You can close this window and return to your terminal.</p>
+        </div>
+      </div>
+    );
+  }
 
   if (error) {
     return <div>{error}</div>;

--- a/test/fr/maif/izanami/api/BaseAPISpec.scala
+++ b/test/fr/maif/izanami/api/BaseAPISpec.scala
@@ -4195,6 +4195,95 @@ object BaseAPISpec extends DefaultAwaitTimeout {
       url.split("code=")(1).split("&")(0)
     }
 
+    def extractStateFromUrl(url: String): String = {
+      url.split("state=")(1).split("&")(0)
+    }
+
+    def generateValidState(): String = {
+      val bytes = new Array[Byte](32)
+      new java.security.SecureRandom().nextBytes(bytes)
+      java.util.Base64.getUrlEncoder.withoutPadding().encodeToString(bytes)
+    }
+
+    def logAsOIDCUserViaCli(
+        username: String,
+        state: String,
+        password: String = "pwd"
+    ): TestSituation = {
+      // 1. Call CLI login endpoint to initiate flow (no cookies returned)
+      val location = await(
+        ws.url(s"${ADMIN_BASE_URL}/cli-login?state=$state")
+          .withFollowRedirects(false)
+          .get()
+          .map(response => {
+            if (response.status >= 400) {
+              throw new RuntimeException(
+                s"Failed to call cli-login endpoint: ${response.status}"
+              )
+            } else {
+              response.header("Location").get
+            }
+          })
+      )
+
+      // 2. Follow OIDC flow (same as logAsOIDCUser)
+      val (antiForgeryCookie, requestVerificationToken) = await(
+        ws.url(location)
+          .get()
+          .map(response => {
+            if (response.status >= 400) {
+              throw new RuntimeException(
+                s"Failed to call OIDC authorize endpoint: status=${response.status}, body=${response.body}"
+              )
+            } else {
+              val antiForgeryCookie =
+                response.cookies.find(c => c.name.contains("Antiforgery"))
+                  .getOrElse(throw new RuntimeException(
+                    s"No Antiforgery cookie found. Location=$location, cookies=${response.cookies.map(_.name)}, status=${response.status}"
+                  ))
+              val requestVerificationToken =
+                extractVerificationToken(response.body)
+              (antiForgeryCookie, requestVerificationToken)
+            }
+          })
+      )
+
+      // 3. Submit login to mock OIDC server
+      val body = Map(
+        "Input.ReturnUrl" -> location.replaceFirst("http://localhost:9001", ""),
+        "Input.Username" -> username,
+        "Input.Password" -> password,
+        "Input.Button" -> "login",
+        "__RequestVerificationToken" -> requestVerificationToken
+      )
+      val response = await(
+        ws.url("http://localhost:9001/Account/Login")
+          .withCookies(antiForgeryCookie)
+          .withFollowRedirects(false)
+          .post(body)
+      )
+
+      // 4. Follow redirects to get code and state
+      val secondResponse = await(
+        ws.url(s"http://localhost:9001${response.header("Location").get}")
+          .withCookies(response.cookies.appended(antiForgeryCookie).toSeq: _*)
+          .withFollowRedirects(false)
+          .get()
+      )
+
+      val urlWithCode = secondResponse.header("Location").get
+      val code = extractCodeFromUrl(urlWithCode)
+      val cliState = extractStateFromUrl(urlWithCode)
+
+      // 5. Call callback with code AND state (CLI flow - no session cookie needed)
+      await(
+        ws.url(s"${ADMIN_BASE_URL}/openid-connect-callback")
+          .post(Json.obj("code" -> code, "state" -> cliState))
+      )
+
+      this // Return same situation - token is now available via polling
+    }
+
     def restartServerWithConf(conf: Map[String, AnyRef]): TestSituation = {
       shouldRestartInstance = true
       stopServer()

--- a/test/fr/maif/izanami/api/BaseAPISpec.scala
+++ b/test/fr/maif/izanami/api/BaseAPISpec.scala
@@ -4148,9 +4148,10 @@ object BaseAPISpec extends DefaultAwaitTimeout {
 
       val urlWithCode = secondResponse.header("Location").get
       val code = extractCodeFromUrl(urlWithCode)
+      val state = extractStateFromUrl(urlWithCode)
 
       val newSituation = await(
-        callOpenIdCallback2(code, playCookie)
+        callOpenIdCallback2(code, state, playCookie)
           .map(response => {
             if (response.status >= 400) {
               throw new RuntimeException(
@@ -4180,6 +4181,7 @@ object BaseAPISpec extends DefaultAwaitTimeout {
 
     private def callOpenIdCallback2(
         code: String,
+        state: String,
         sessionCookie: WSCookie
     ): Future[WSResponse] = {
       ws.url(s"""${ADMIN_BASE_URL}/openid-connect-callback""")
@@ -4187,7 +4189,7 @@ object BaseAPISpec extends DefaultAwaitTimeout {
           sessionCookie
         )
         .post(
-          Json.obj("code" -> code)
+          Json.obj("code" -> code, "state" -> state)
         )
     }
 

--- a/test/fr/maif/izanami/api/LoginAPISpec.scala
+++ b/test/fr/maif/izanami/api/LoginAPISpec.scala
@@ -142,4 +142,106 @@ class LoginAPISpec extends BaseAPISpec {
 
   
 
+  "CLI OIDC authentication" should {
+    "reject invalid state format" in {
+      TestSituationBuilder()
+        .withCustomConfiguration(baseOIDCConfiguration)
+        .build()
+
+      val response = await(
+        ws.url(s"${ADMIN_BASE_URL}/cli-login?state=invalid")
+          .withFollowRedirects(false)
+          .get()
+      )
+      response.status mustBe BAD_REQUEST
+    }
+
+    "redirect to OIDC provider with valid state" in {
+      val situation = TestSituationBuilder()
+        .withCustomConfiguration(baseOIDCConfiguration)
+        .build()
+
+      val state = situation.generateValidState()
+      val response = await(
+        ws.url(s"${ADMIN_BASE_URL}/cli-login?state=$state")
+          .withFollowRedirects(false)
+          .get()
+      )
+      response.status mustBe SEE_OTHER
+      response.header("Location").get must include("authorize")
+      response.header("Location").get must include(s"state=cli:$state")
+    }
+
+    "return 202 when polling before auth completes" in {
+      val situation = TestSituationBuilder()
+        .withCustomConfiguration(baseOIDCConfiguration)
+        .build()
+
+      val state = situation.generateValidState()
+      // Initiate CLI login (stores pending auth)
+      await(
+        ws.url(s"${ADMIN_BASE_URL}/cli-login?state=$state")
+          .withFollowRedirects(false)
+          .get()
+      )
+
+      // Poll before completing auth
+      val pollResponse = await(
+        ws.url(s"${ADMIN_BASE_URL}/cli-token?state=$state").get()
+      )
+      pollResponse.status mustBe ACCEPTED
+      (pollResponse.json \ "status").as[String] mustBe "pending"
+    }
+
+    "return 404 for unknown state" in {
+      TestSituationBuilder()
+        .withCustomConfiguration(baseOIDCConfiguration)
+        .build()
+
+      val state = java.util.Base64.getUrlEncoder.withoutPadding()
+        .encodeToString(new Array[Byte](32).map(_ => 'a'.toByte))
+      val response = await(
+        ws.url(s"${ADMIN_BASE_URL}/cli-token?state=$state").get()
+      )
+      response.status mustBe NOT_FOUND
+    }
+
+    "complete full CLI auth flow and return token" in {
+      val situation = TestSituationBuilder()
+        .withCustomConfiguration(baseOIDCConfiguration)
+        .build()
+
+      val state = situation.generateValidState()
+      situation.logAsOIDCUserViaCli("User1", state)
+
+      // Poll for token
+      val pollResponse = await(
+        ws.url(s"${ADMIN_BASE_URL}/cli-token?state=$state").get()
+      )
+      pollResponse.status mustBe OK
+      (pollResponse.json \ "token").asOpt[String] mustBe defined
+    }
+
+    "return token only once (single-use)" in {
+      val situation = TestSituationBuilder()
+        .withCustomConfiguration(baseOIDCConfiguration)
+        .build()
+
+      val state = situation.generateValidState()
+      situation.logAsOIDCUserViaCli("User1", state)
+
+      // First poll should succeed
+      val firstPoll = await(
+        ws.url(s"${ADMIN_BASE_URL}/cli-token?state=$state").get()
+      )
+      firstPoll.status mustBe OK
+
+      // Second poll should fail (token already claimed)
+      val secondPoll = await(
+        ws.url(s"${ADMIN_BASE_URL}/cli-token?state=$state").get()
+      )
+      secondPoll.status mustBe NOT_FOUND
+    }
+  }
+
 }


### PR DESCRIPTION
## Pull Request: CLI Authentication via OpenID Connect

### Summary

This PR adds support for CLI OIDC authentication, enabling command-line tools (like the Izanami Go CLI -> https://github.com/webskin/izanami-go-cli/releases) to authenticate users through an OpenID Connect provider using a browser-based flow with state-based token polling.

### Motivation

CLI tools need a secure way to authenticate users via OIDC without requiring:
- A local HTTP callback server (complex firewall/NAT issues)
- Manual copy-paste of tokens (error-prone, poor UX)

This implementation uses a polling-based approach where the CLI opens a browser for authentication and polls the server for the resulting token.

### Changes

**New Files:**
| File | Description |
|------|-------------|
| `CliAuthDatastore.scala` | Pluggable storage abstraction with factory pattern |
| `InMemoryCliAuthStorage.scala` | Thread-safe storage with automatic cleanup for single-instance deployments |
| `PostgresCliAuthStorage.scala` | Database-backed storage for load-balanced/clustered setups |
| `CliAuthentication.scala` | Models for `PendingCliAuth` and `CompletedCliAuth` with configurable TTLs |
| `V22__create_cli_auth_table.sql` | PostgreSQL migration for CLI auth tables |

**Modified Files:**
| File | Changes |
|------|---------|
| `LoginController.scala` | Added `cliOpenIdConnect` and `cliTokenPoll` endpoints |
| `Errors.scala` | Added CLI-specific error types |
| `login.tsx` | Enhanced to detect CLI auth and show completion message |
| `application.conf` | Added `IZANAMI_CLI_AUTH_STORAGE` configuration |

### New API Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/admin/cli-login?state={state}` | GET | Initiate CLI OIDC flow, returns redirect to OIDC provider |
| `/api/admin/cli-token?state={state}` | GET | Poll for token after authentication |

**Token Polling Responses:**
- `200 OK` - Authentication complete, returns JWT token
- `202 Accepted` - Authentication pending, keep polling
- `404 Not Found` - Invalid or unknown state
- `410 Gone` - Token expired (already claimed or TTL exceeded)
- `429 Too Many Requests` - Rate limited, includes `Retry-After` header

### Authentication Flow

```
┌─────────┐                    ┌─────────────┐                    ┌──────────────┐
│   CLI   │                    │   Izanami   │                    │ OIDC Provider│
└────┬────┘                    └──────┬──────┘                    └──────┬───────┘
     │ 1. Generate state              │                                  │
     │ 2. GET /cli-login?state=...    │                                  │
     │ ───────────────────────────>   │                                  │
     │ <───────────────────────────   │ 3. Store pending auth            │
     │    302 Redirect to OIDC        │                                  │
     │ 4. Open browser ───────────────┼──────────────────────────────>   │
     │ 5. Start polling               │    6. User authenticates         │
     │ ───────────────────────────>   │ <─────────────────────────────   │
     │    GET /cli-token?state=...    │    Callback with code + state    │
     │ <───────────────────────────   │ 7. Exchange code, store token    │
     │    202 (pending) / 200 (ready) │                                  │
     │ 8. Receive JWT token           │ 9. Delete token (single-use)     │
     └────────────────────────────────┴──────────────────────────────────┘
```

### Security Features

| Feature | Implementation |
|---------|----------------|
| **State Entropy** | 256-bit random state prevents guessing attacks |
| **CSRF Protection** | State parameter passed through OIDC flow with `cli:` prefix |
| **Single-Use Tokens** | Token deleted from server after first retrieval |
| **Rate Limiting** | 60 poll requests per minute per state |
| **Short TTLs** | 5 min for pending auth, 2 min for completed token pickup |
| **PKCE Support** | Uses PKCE with OIDC provider when available |

### Configuration

| Variable | Values | Default | Description |
|----------|--------|---------|-------------|
| `IZANAMI_CLI_AUTH_STORAGE` | `in-memory`, `postgresql` | `in-memory` | Storage backend for CLI auth state |

- **in-memory**: Suitable for single-instance deployments, uses thread-safe concurrent maps with scheduled cleanup
- **postgresql**: Required for clustered/load-balanced deployments, stores state in database

### Testing

- Added `LoginAPISpec` tests for CLI OIDC endpoints
- Fixed existing OIDC callback tests to include state parameter

### CLI Usage (izanami-go-cli)

```bash
# OIDC login - opens browser, polls for token automatically
iz login --oidc --url https://izanami.example.com

# With custom timeout
iz login --oidc --url https://izanami.example.com --timeout 10m

# Headless mode (print URL, don't open browser)
iz login --oidc --url https://izanami.example.com --no-browser
```

### Breaking Changes

None. This is a purely additive feature.

### Checklist

- [x] New endpoints documented in routes
- [x] PostgreSQL migration included
- [x] In-memory storage for development/single-instance
- [x] PostgreSQL storage for production clusters
- [x] Rate limiting implemented
- [x] Security measures (CSRF, single-use, short TTLs)
- [x] Frontend updated for CLI auth completion
- [x] Tests added for new endpoints
